### PR TITLE
refactor: 솔루션 페이지 위젯 통일 및 네비/CTA 정리

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -61,27 +61,27 @@ export const headerData = {
         },
       ],
     },
-    {
-      text: resolveI18nPair('nav.resources.title') || 'Resources',
-      links: [
-        {
-          text: resolveI18nPair('nav.resources.submenu.corporate') || 'Corporate News',
-          href: getPermalink('corporate', 'category'),
-        },
-        {
-          text: resolveI18nPair('nav.resources.submenu.case_study') || 'Case Studies',
-          href: getPermalink('case-studies', 'category'),
-        },
-        {
-          text: resolveI18nPair('nav.resources.submenu.tech_insight') || 'Tech Insight',
-          href: getPermalink('tech-insight', 'category'),
-        },
-        {
-          text: resolveI18nPair('nav.resources.submenu.culture_people') || 'Culture & People',
-          href: getPermalink('culture', 'category'),
-        },
-      ],
-    },
+    // {
+    //   text: resolveI18nPair('nav.resources.title') || 'Resources',
+    //   links: [
+    //     {
+    //       text: resolveI18nPair('nav.resources.submenu.corporate') || 'Corporate News',
+    //       href: getPermalink('corporate', 'category'),
+    //     },
+    //     {
+    //       text: resolveI18nPair('nav.resources.submenu.case_study') || 'Case Studies',
+    //       href: getPermalink('case-studies', 'category'),
+    //     },
+    //     {
+    //       text: resolveI18nPair('nav.resources.submenu.tech_insight') || 'Tech Insight',
+    //       href: getPermalink('tech-insight', 'category'),
+    //     },
+    //     {
+    //       text: resolveI18nPair('nav.resources.submenu.culture_people') || 'Culture & People',
+    //       href: getPermalink('culture', 'category'),
+    //     },
+    //   ],
+    // },
   ],
   actions: [],
 };
@@ -116,15 +116,15 @@ const footerSitemap: Array<{ title: string; links: Array<{ text: string; href: s
       { text: 'Document AI (IDA)', href: getPermalink('/solutions/ida') },
     ],
   },
-  {
-    title: 'Resources',
-    links: [
-      { text: 'Corporate News', href: getPermalink('corporate', 'category') },
-      { text: 'Case Studies', href: getPermalink('case-studies', 'category') },
-      { text: 'Tech Insight', href: getPermalink('tech-insight', 'category') },
-      { text: 'Culture & People', href: getPermalink('culture', 'category') },
-    ],
-  },
+  // {
+  //   title: 'Resources',
+  //   links: [
+  //     { text: 'Corporate News', href: getPermalink('corporate', 'category') },
+  //     { text: 'Case Studies', href: getPermalink('case-studies', 'category') },
+  //     { text: 'Tech Insight', href: getPermalink('tech-insight', 'category') },
+  //     { text: 'Culture & People', href: getPermalink('culture', 'category') },
+  //   ],
+  // },
 ];
 
 export const footerData = {
@@ -140,7 +140,7 @@ export const footerData = {
     // { ariaLabel: 'Facebook', icon: 'tabler:brand-facebook', href: '#' },
     // { ariaLabel: 'Github', icon: 'tabler:brand-github', href: 'https://github.com/arthelokyo/astrowind' },
   ],
-  footNote: `
-    Made by <a class="text-blue-600 underline dark:text-muted" href="https://github.com/arthelokyo"> Arthelokyo</a> · All rights reserved.
-  `,
+  // footNote: `
+  //   Made by <a class="text-blue-600 underline dark:text-muted" href="https://github.com/arthelokyo"> Arthelokyo</a> · All rights reserved.
+  // `,
 };

--- a/src/pages/category/case-studies.astro
+++ b/src/pages/category/case-studies.astro
@@ -3,7 +3,6 @@ import Layout from '~/layouts/PageLayout.astro';
 
 import Hero2 from '~/components/widgets/Hero2.astro';
 import BlogLatestPosts from '~/components/widgets/BlogLatestPosts.astro';
-import CallToAction from '~/components/widgets/CallToAction.astro';
 
 const metadata = {
   title: 'Case Studies — MetaIntelligence',
@@ -34,10 +33,4 @@ const metadata = {
     emptyMessage="현재 공개 가능한 사례를 정리하고 있습니다. 비공개 도입 사례 자료가 필요하시면 문의해 주세요."
   />
 
-  <CallToAction actions={[{ variant: 'primary', text: '도입 문의하기', href: '/contact', icon: 'tabler:mail' }]}>
-    <Fragment slot="title">우리 현장에 어떻게 적용될까요?</Fragment>
-    <Fragment slot="subtitle">
-      귀사의 데이터와 공정에 맞춘 PoC 설계부터 단계적 도입까지, 전 과정을 함께합니다.
-    </Fragment>
-  </CallToAction>
 </Layout>

--- a/src/pages/category/case-studies.astro
+++ b/src/pages/category/case-studies.astro
@@ -32,5 +32,4 @@ const metadata = {
     count={6}
     emptyMessage="현재 공개 가능한 사례를 정리하고 있습니다. 비공개 도입 사례 자료가 필요하시면 문의해 주세요."
   />
-
 </Layout>

--- a/src/pages/category/corporate.astro
+++ b/src/pages/category/corporate.astro
@@ -3,7 +3,6 @@ import Layout from '~/layouts/PageLayout.astro';
 
 import Hero2 from '~/components/widgets/Hero2.astro';
 import BlogLatestPosts from '~/components/widgets/BlogLatestPosts.astro';
-import CallToAction from '~/components/widgets/CallToAction.astro';
 
 const metadata = {
   title: 'Corporate News — MetaIntelligence',
@@ -33,8 +32,4 @@ const metadata = {
     emptyMessage="첫 번째 공식 소식을 곧 전해드리겠습니다. 조금만 기다려 주세요."
   />
 
-  <CallToAction actions={[{ variant: 'primary', text: 'Contact Us', href: '/contact', icon: 'tabler:mail' }]}>
-    <Fragment slot="title">함께할 미래를 제안합니다</Fragment>
-    <Fragment slot="subtitle"> 파트너십, 투자, 미디어 문의는 언제든지 환영합니다. </Fragment>
-  </CallToAction>
 </Layout>

--- a/src/pages/category/corporate.astro
+++ b/src/pages/category/corporate.astro
@@ -31,5 +31,4 @@ const metadata = {
     count={6}
     emptyMessage="첫 번째 공식 소식을 곧 전해드리겠습니다. 조금만 기다려 주세요."
   />
-
 </Layout>

--- a/src/pages/category/culture.astro
+++ b/src/pages/category/culture.astro
@@ -3,7 +3,6 @@ import Layout from '~/layouts/PageLayout.astro';
 
 import Hero2 from '~/components/widgets/Hero2.astro';
 import BlogLatestPosts from '~/components/widgets/BlogLatestPosts.astro';
-import CallToAction from '~/components/widgets/CallToAction.astro';
 
 const metadata = {
   title: 'Culture & People — MetaIntelligence',
@@ -34,10 +33,4 @@ const metadata = {
     emptyMessage="동료들의 첫 번째 이야기를 정리하고 있습니다. 곧 이 자리에서 만나보실 수 있습니다."
   />
 
-  <CallToAction actions={[{ variant: 'primary', text: '함께 일하기', href: '/contact', icon: 'tabler:users' }]}>
-    <Fragment slot="title">같은 본질을 보는 동료를 찾습니다</Fragment>
-    <Fragment slot="subtitle">
-      가장 단단한 엔지니어링과 가장 따뜻한 협업이 만나는 곳. 채용 정보를 곧 업데이트합니다.
-    </Fragment>
-  </CallToAction>
 </Layout>

--- a/src/pages/category/culture.astro
+++ b/src/pages/category/culture.astro
@@ -32,5 +32,4 @@ const metadata = {
     count={6}
     emptyMessage="동료들의 첫 번째 이야기를 정리하고 있습니다. 곧 이 자리에서 만나보실 수 있습니다."
   />
-
 </Layout>

--- a/src/pages/category/tech-insight.astro
+++ b/src/pages/category/tech-insight.astro
@@ -3,7 +3,6 @@ import Layout from '~/layouts/PageLayout.astro';
 
 import Hero2 from '~/components/widgets/Hero2.astro';
 import BlogLatestPosts from '~/components/widgets/BlogLatestPosts.astro';
-import CallToAction from '~/components/widgets/CallToAction.astro';
 
 const metadata = {
   title: 'Tech Insight — MetaIntelligence',
@@ -34,10 +33,4 @@ const metadata = {
     emptyMessage="첫 번째 기술 글을 다듬고 있습니다. 출시되는 대로 이곳에서 가장 먼저 만나보실 수 있습니다."
   />
 
-  <CallToAction actions={[{ variant: 'primary', text: '기술 문의', href: '/contact', icon: 'tabler:mail' }]}>
-    <Fragment slot="title">함께 풀어볼 문제가 있으신가요?</Fragment>
-    <Fragment slot="subtitle">
-      벤치마크에 갇히지 않은, 실제 운영 환경에서 작동하는 기술을 함께 만들어 갑니다.
-    </Fragment>
-  </CallToAction>
 </Layout>

--- a/src/pages/category/tech-insight.astro
+++ b/src/pages/category/tech-insight.astro
@@ -32,5 +32,4 @@ const metadata = {
     count={6}
     emptyMessage="첫 번째 기술 글을 다듬고 있습니다. 출시되는 대로 이곳에서 가장 먼저 만나보실 수 있습니다."
   />
-
 </Layout>

--- a/src/pages/company/culture.astro
+++ b/src/pages/company/culture.astro
@@ -5,7 +5,6 @@ import Header from '~/components/widgets/Header.astro';
 import Hero2 from '~/components/widgets/Hero2.astro';
 import Content from '~/components/widgets/Content.astro';
 import Features3 from '~/components/widgets/Features3.astro';
-import CallToAction from '~/components/widgets/CallToAction.astro';
 
 import { headerData } from '~/navigation';
 
@@ -104,17 +103,4 @@ const metadata = {
     ]}
   />
 
-  <CallToAction
-    actions={[
-      {
-        variant: 'primary',
-        text: 'Join the Team',
-        href: '/contact', // 혹은 채용 페이지 링크
-        icon: 'tabler:briefcase',
-      },
-    ]}
-  >
-    <Fragment slot="title"> Be a Builder </Fragment>
-    <Fragment slot="subtitle"> 최고의 동료들과 함께, 세상에 없던 가치를 설계하고 싶다면 지금 합류하세요. </Fragment>
-  </CallToAction>
 </Layout>

--- a/src/pages/company/culture.astro
+++ b/src/pages/company/culture.astro
@@ -101,5 +101,4 @@ const metadata = {
       },
     ]}
   />
-
 </Layout>

--- a/src/pages/company/culture.astro
+++ b/src/pages/company/culture.astro
@@ -20,7 +20,6 @@ const metadata = {
 
   <Hero2
     tagline="Organizational Culture"
-    actions={[{ variant: 'primary', text: 'Join Us', href: '/contact' }]}
     image={{
       src: 'https://images.unsplash.com/photo-1522071820081-009f0129c71c?ixlib=rb-4.0.3&auto=format&fit=crop&w=2070&q=80',
       alt: 'MetaIntelligence Team Culture',

--- a/src/pages/company/identity.astro
+++ b/src/pages/company/identity.astro
@@ -3,7 +3,6 @@ import Layout from '~/layouts/PageLayout.astro';
 
 import Header from '~/components/widgets/Header.astro';
 import Hero2 from '~/components/widgets/Hero2.astro';
-import Steps2 from '~/components/widgets/Steps2.astro';
 import Content from '~/components/widgets/Content.astro';
 import Features2 from '~/components/widgets/Features2.astro';
 import Stats from '~/components/widgets/Stats.astro';
@@ -130,25 +129,4 @@ const metadata = {
     ]}
   />
 
-  <Steps2
-    id="contact"
-    title="함께 미래를 설계하세요"
-    subtitle="MetaIntelligence의 철학에 공감하신다면, 지금 바로 연락주세요."
-    callToAction={{
-      text: 'Contact Us',
-      href: '/contact',
-    }}
-    items={[
-      {
-        title: 'Email',
-        description: 'contact@metaintelligence.io',
-        icon: 'tabler:mail',
-      },
-      {
-        title: 'Location',
-        description: 'Seoul, Republic of Korea',
-        icon: 'tabler:map-pin',
-      },
-    ]}
-  />
 </Layout>

--- a/src/pages/company/identity.astro
+++ b/src/pages/company/identity.astro
@@ -38,7 +38,8 @@ const metadata = {
 
     <Fragment slot="subtitle">
       MetaIntelligence는 단순한 기술 구현을 넘어, 인류가 마주한 복잡한 문제의 <strong>본질을 통찰</strong>하고 실질적인
-      <strong>가치를 설계</strong>합니다. 공학적 완성도를 바탕으로 산업 현장에 지능형 솔루션을 이식하는 것이 우리의 사명입니다.
+      <strong>가치를 설계</strong>합니다. 공학적 완성도를 바탕으로 산업 현장에 지능형 솔루션을 이식하는 것이 우리의
+      사명입니다.
     </Fragment>
   </Hero2>
 
@@ -125,5 +126,4 @@ const metadata = {
       { title: 'Client Satisfaction', amount: '98%' },
     ]}
   />
-
 </Layout>

--- a/src/pages/company/identity.astro
+++ b/src/pages/company/identity.astro
@@ -26,10 +26,7 @@ const metadata = {
 
   <Hero2
     tagline="Who We Are"
-    actions={[
-      { variant: 'primary', text: 'Our Technology', href: '/tech/core-tech' },
-      { text: 'Contact Us', href: '#contact' },
-    ]}
+    actions={[{ variant: 'primary', text: 'Our Technology', href: '/tech/core-tech' }]}
     image={{
       src: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?auto=format&fit=crop&w=2072&q=80',
       alt: 'MetaIntelligence Identity Image',
@@ -40,8 +37,8 @@ const metadata = {
     </Fragment>
 
     <Fragment slot="subtitle">
-      MetaIntelligence는 단순한 기술 구현을 넘어, 인류가 마주한 복잡한 문제의 **본질을 통찰**하고 실질적인 **가치를
-      설계**합니다. 공학적 완성도를 바탕으로 산업 현장에 지능형 솔루션을 이식하는 것이 우리의 사명입니다.
+      MetaIntelligence는 단순한 기술 구현을 넘어, 인류가 마주한 복잡한 문제의 <strong>본질을 통찰</strong>하고 실질적인
+      <strong>가치를 설계</strong>합니다. 공학적 완성도를 바탕으로 산업 현장에 지능형 솔루션을 이식하는 것이 우리의 사명입니다.
     </Fragment>
   </Hero2>
 

--- a/src/pages/company/intro.astro
+++ b/src/pages/company/intro.astro
@@ -3,7 +3,6 @@ import Layout from '~/layouts/PageLayout.astro';
 
 import Header from '~/components/widgets/Header.astro';
 import Hero2 from '~/components/widgets/Hero2.astro';
-import Steps2 from '~/components/widgets/Steps2.astro';
 import Content from '~/components/widgets/Content.astro';
 import Features2 from '~/components/widgets/Features2.astro';
 import Stats from '~/components/widgets/Stats.astro';
@@ -130,25 +129,4 @@ const metadata = {
     ]}
   />
 
-  <Steps2
-    id="contact"
-    title="함께 미래를 설계하세요"
-    subtitle="MetaIntelligence의 철학에 공감하신다면, 지금 바로 연락주세요."
-    callToAction={{
-      text: 'Contact Us',
-      href: '/contact',
-    }}
-    items={[
-      {
-        title: 'Email',
-        description: 'contact@metaintelligence.io',
-        icon: 'tabler:mail',
-      },
-      {
-        title: 'Location',
-        description: 'Seoul, Republic of Korea',
-        icon: 'tabler:map-pin',
-      },
-    ]}
-  />
 </Layout>

--- a/src/pages/company/intro.astro
+++ b/src/pages/company/intro.astro
@@ -38,7 +38,8 @@ const metadata = {
 
     <Fragment slot="subtitle">
       MetaIntelligence는 단순한 기술 구현을 넘어, 인류가 마주한 복잡한 문제의 <strong>본질을 통찰</strong>하고 실질적인
-      <strong>가치를 설계</strong>합니다. 공학적 완성도를 바탕으로 산업 현장에 지능형 솔루션을 이식하는 것이 우리의 사명입니다.
+      <strong>가치를 설계</strong>합니다. 공학적 완성도를 바탕으로 산업 현장에 지능형 솔루션을 이식하는 것이 우리의
+      사명입니다.
     </Fragment>
   </Hero2>
 
@@ -125,5 +126,4 @@ const metadata = {
       { title: 'Client Satisfaction', amount: '98%' },
     ]}
   />
-
 </Layout>

--- a/src/pages/company/intro.astro
+++ b/src/pages/company/intro.astro
@@ -26,10 +26,7 @@ const metadata = {
 
   <Hero2
     tagline="Who We Are"
-    actions={[
-      { variant: 'primary', text: 'Our Technology', href: '/tech/core-tech' },
-      { text: 'Contact Us', href: '#contact' },
-    ]}
+    actions={[{ variant: 'primary', text: 'Our Technology', href: '/tech/core-tech' }]}
     image={{
       src: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?auto=format&fit=crop&w=2072&q=80',
       alt: 'MetaIntelligence Identity Image',
@@ -40,8 +37,8 @@ const metadata = {
     </Fragment>
 
     <Fragment slot="subtitle">
-      MetaIntelligence는 단순한 기술 구현을 넘어, 인류가 마주한 복잡한 문제의 **본질을 통찰**하고 실질적인 **가치를
-      설계**합니다. 공학적 완성도를 바탕으로 산업 현장에 지능형 솔루션을 이식하는 것이 우리의 사명입니다.
+      MetaIntelligence는 단순한 기술 구현을 넘어, 인류가 마주한 복잡한 문제의 <strong>본질을 통찰</strong>하고 실질적인
+      <strong>가치를 설계</strong>합니다. 공학적 완성도를 바탕으로 산업 현장에 지능형 솔루션을 이식하는 것이 우리의 사명입니다.
     </Fragment>
   </Hero2>
 

--- a/src/pages/company/mission-history.astro
+++ b/src/pages/company/mission-history.astro
@@ -5,7 +5,6 @@ import Header from '~/components/widgets/Header.astro';
 import Hero2 from '~/components/widgets/Hero2.astro';
 import Steps from '~/components/widgets/Steps.astro'; // 타임라인용 위젯
 import Features3 from '~/components/widgets/Features3.astro'; // 미션 강조용 위젯
-import CallToAction from '~/components/widgets/CallToAction.astro';
 
 import { headerData } from '~/navigation';
 import { I18N } from 'metaintelligence:config';
@@ -93,16 +92,4 @@ const historyItems = [
     }}
   />
 
-  <CallToAction
-    actions={[
-      {
-        variant: 'primary',
-        text: 'Contact Us',
-        href: '/contact',
-      },
-    ]}
-  >
-    <Fragment slot="title"> MetaIntelligence </Fragment>
-    <Fragment slot="subtitle"> 함께 더 큰 미래를 만들어갈 파트너를 기다립니다. </Fragment>
-  </CallToAction>
 </Layout>

--- a/src/pages/company/mission-history.astro
+++ b/src/pages/company/mission-history.astro
@@ -91,5 +91,4 @@ const historyItems = [
       alt: 'History Timeline Image',
     }}
   />
-
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,6 @@ import Steps from '~/components/widgets/Steps.astro';
 import Content from '~/components/widgets/Content.astro';
 import BlogLatestPosts from '~/components/widgets/BlogLatestPosts.astro';
 import Stats from '~/components/widgets/Stats.astro';
-import CallToAction from '~/components/widgets/CallToAction.astro';
 import Logo from '~/components/Logo.astro';
 import { getPermalink } from '~/utils/permalinks';
 import { resolveI18nPair } from '~/utils/i18n';
@@ -152,20 +151,4 @@ const metadata = {
     linkUrl={getPermalink('tech-insight', 'category')}
   />
 
-  <CallToAction
-    actions={[
-      {
-        variant: 'primary',
-        text: 'Contact Us',
-        href: '/contact',
-        icon: 'tabler:mail',
-      },
-    ]}
-  >
-    <Fragment slot="title"> AX 2035: 산업 지능의 운영체제 </Fragment>
-    <Fragment slot="subtitle">
-      데이터가 흐르는 모든 산업 현장에 MetaIntelligence의 기술을 이식합니다. <br />
-      지금 바로 귀사의 문제를 본질부터 해결해 보세요.
-    </Fragment>
-  </CallToAction>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -150,5 +150,4 @@ const metadata = {
     linkText="기술 블로그 전체 보기"
     linkUrl={getPermalink('tech-insight', 'category')}
   />
-
 </Layout>

--- a/src/pages/solutions/ida.astro
+++ b/src/pages/solutions/ida.astro
@@ -3,7 +3,6 @@ import { Icon } from 'astro-icon/components';
 
 import Layout from '~/layouts/PageLayout.astro';
 import Header from '~/components/widgets/Header.astro';
-import CallToAction from '~/components/widgets/CallToAction.astro';
 
 import { headerData } from '~/navigation';
 
@@ -455,22 +454,6 @@ const operationItems = [
       </div>
     </div>
   </section>
-
-  <CallToAction
-    actions={[
-      {
-        variant: 'primary',
-        text: '도입 문의',
-        href: '/contact',
-        icon: 'tabler:message-circle',
-      },
-    ]}
-  >
-    <Fragment slot="title">문서·레코드에서 실행 가능한 인사이트를 찾으세요.</Fragment>
-    <Fragment slot="subtitle">
-      IDA는 업로드, 클러스터링, 정량 평가, 인사이트 생성을 하나의 분석 흐름으로 제공합니다.
-    </Fragment>
-  </CallToAction>
 
   <script is:inline data-astro-rerun>
     (() => {

--- a/src/pages/solutions/ida.astro
+++ b/src/pages/solutions/ida.astro
@@ -210,9 +210,7 @@ const initialScreen = screenItems[1];
               type="button"
               class:list={[
                 'group relative z-40 w-full cursor-pointer select-none overflow-hidden rounded-md border p-0 text-left transition bg-white dark:bg-slate-900 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary pointer-events-auto',
-                index === 1
-                  ? 'border-primary ring-1 ring-primary'
-                  : 'border-gray-200 dark:border-slate-700',
+                index === 1 ? 'border-primary ring-1 ring-primary' : 'border-gray-200 dark:border-slate-700',
               ]}
               data-ida-screen-trigger
               data-ida-active={index === 1 ? 'true' : 'false'}
@@ -311,8 +309,8 @@ const initialScreen = screenItems[1];
   >
     <Fragment slot="content">
       <p class="text-lg leading-relaxed text-muted dark:text-slate-400">
-        MetaInsight는 분석 엔진만이 아니라 계정, 프로젝트, 결과 저장, 내보내기, 모바일 대응 화면까지 포함한 제품형 구조를
-        갖추고 있습니다. IDA는 이 기반 위에서 기업 문서·규제·과제 데이터 분석 영역으로 확장됩니다.
+        MetaInsight는 분석 엔진만이 아니라 계정, 프로젝트, 결과 저장, 내보내기, 모바일 대응 화면까지 포함한 제품형
+        구조를 갖추고 있습니다. IDA는 이 기반 위에서 기업 문서·규제·과제 데이터 분석 영역으로 확장됩니다.
       </p>
     </Fragment>
   </Content>

--- a/src/pages/solutions/ida.astro
+++ b/src/pages/solutions/ida.astro
@@ -1,8 +1,14 @@
 ---
-import { Icon } from 'astro-icon/components';
-
 import Layout from '~/layouts/PageLayout.astro';
 import Header from '~/components/widgets/Header.astro';
+import Hero2 from '~/components/widgets/Hero2.astro';
+import Features3 from '~/components/widgets/Features3.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import Features2 from '~/components/widgets/Features2.astro';
+import Content from '~/components/widgets/Content.astro';
+import WidgetWrapper from '~/components/ui/WidgetWrapper.astro';
+import Headline from '~/components/ui/Headline.astro';
+import { Icon } from 'astro-icon/components';
 
 import { headerData } from '~/navigation';
 
@@ -18,86 +24,6 @@ const metadata = {
   description:
     'IDA는 MetaInsight 기반의 문서·레코드 분석 AI로, CSV·Excel·Parquet 데이터에서 텍스트 클러스터와 시계열 시그널을 발견하고 정량 근거 기반 인사이트를 생성합니다.',
 };
-
-const summaryStats = [
-  {
-    value: 'CSV / Excel',
-    label: '업로드 기반 분석 시작',
-  },
-  {
-    value: 'C1·C2·C3',
-    label: '시그널 강도 평가',
-  },
-  {
-    value: 'Export',
-    label: 'Excel·CSV 결과 내보내기',
-  },
-];
-
-const capabilityItems = [
-  {
-    title: '문서·레코드 업로드',
-    description:
-      'CSV, Excel, Parquet 파일을 업로드하고 텍스트, 날짜, 금액, 그룹, 식별자 컬럼을 화면에서 확인하며 분석 조건을 구성합니다.',
-    icon: 'tabler:file-spreadsheet',
-    tone: 'text-blue-700 bg-blue-50 dark:bg-blue-950/50 dark:text-blue-300',
-  },
-  {
-    title: '키워드 클러스터링',
-    description:
-      '비슷한 키워드와 문서 항목을 자동으로 묶고, 각 클러스터가 시간에 따라 어떻게 변화하는지 정량적으로 비교합니다.',
-    icon: 'tabler:category-2',
-    tone: 'text-emerald-700 bg-emerald-50 dark:bg-emerald-950/50 dark:text-emerald-300',
-  },
-  {
-    title: '정량 근거 기반 인사이트',
-    description:
-      'C1 장기 트렌드, C2 모멘텀 유지, C3 최근 가속 기준을 바탕으로 등급과 점수를 산출하고 자연어 인사이트를 제공합니다.',
-    icon: 'tabler:report-analytics',
-    tone: 'text-amber-700 bg-amber-50 dark:bg-amber-950/50 dark:text-amber-300',
-  },
-];
-
-const workflowItems = [
-  {
-    label: '01',
-    title: 'Upload',
-    description: '분석할 문서·레코드 데이터를 업로드하고 지원 형식을 확인합니다.',
-  },
-  {
-    label: '02',
-    title: 'Map Columns',
-    description: '텍스트와 날짜 컬럼을 중심으로 분석에 필요한 필드를 매핑합니다.',
-  },
-  {
-    label: '03',
-    title: 'Evaluate',
-    description: '키워드 군집을 만들고 트렌드 강도, 모멘텀, 최근 가속을 평가합니다.',
-  },
-  {
-    label: '04',
-    title: 'Review Insights',
-    description: '요약 지표, 상세 항목, AI 또는 템플릿 기반 인사이트를 검토합니다.',
-  },
-];
-
-const signalCriteria = [
-  {
-    title: 'C1',
-    label: '장기 트렌드',
-    description: '시간이 지나며 꾸준히 증가하는 클러스터인지 확인합니다.',
-  },
-  {
-    title: 'C2',
-    label: '모멘텀 유지',
-    description: '최근 구간의 활동이 기준선보다 높은 상태를 유지하는지 봅니다.',
-  },
-  {
-    title: 'C3',
-    label: '최근 가속',
-    description: '현재 시점에 가까워질수록 격차가 더 커지는지 평가합니다.',
-  },
-];
 
 const screenItems = [
   {
@@ -138,25 +64,6 @@ const screenItems = [
 ];
 
 const initialScreen = screenItems[1];
-
-const operationItems = [
-  {
-    title: 'SaaS 운용 구조',
-    description: 'JWT 인증, 프로젝트 단위 관리, 사용량 제한 등 SaaS 제품 운용에 필요한 기본 구조를 갖춥니다.',
-    icon: 'tabler:shield-check',
-  },
-  {
-    title: '도메인 확장',
-    description:
-      'R&D 과제, 특허, 리테일, 금융 리스크처럼 텍스트와 날짜 축이 있는 데이터로 분석 대상을 확장할 수 있습니다.',
-    icon: 'tabler:database-search',
-  },
-  {
-    title: '반복 탐색',
-    description: '국가, 분야, 기간, 프리셋 등 조건을 조정하며 같은 데이터에서 다른 관점의 시그널을 확인합니다.',
-    icon: 'tabler:refresh-dot',
-  },
-];
 ---
 
 <Layout metadata={metadata}>
@@ -164,296 +71,251 @@ const operationItems = [
     <Header {...headerData} isSticky showToggleTheme />
   </Fragment>
 
-  <section class="relative not-prose overflow-hidden bg-white dark:bg-slate-950">
-    <div class="relative max-w-7xl mx-auto px-4 sm:px-6">
-      <div class="grid lg:grid-cols-[0.9fr_1.1fr] gap-10 lg:gap-14 items-center py-10 md:py-14">
-        <div class="min-w-0">
-          <p class="text-sm font-bold tracking-wide uppercase text-blue-700 dark:text-blue-300">
-            IDA · Intelligent Document Analyzer
-          </p>
-          <h1
-            class="mt-4 text-[2.25rem] sm:text-5xl xl:text-[3.35rem] font-bold leading-[1.08] tracking-tight font-heading dark:text-white"
-          >
-            문서 데이터를
-            <span class="block text-blue-700 dark:text-blue-300">정량 근거로 분석</span>
-          </h1>
-          <p class="mt-6 max-w-2xl text-lg md:text-xl leading-relaxed text-muted dark:text-slate-300">
-            IDA는 MetaInsight의 제품 경험을 기반으로, 구조화된 문서·레코드 데이터에서 키워드 클러스터와 시계열 시그널을
-            찾고 분석 결과를 인사이트로 정리하는 문서 분석 AI 솔루션입니다.
-          </p>
-          <div class="mt-8 grid sm:grid-cols-3 gap-3 max-w-2xl">
-            {
-              summaryStats.map((item) => (
-                <div class="rounded-lg border border-stone-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-4">
-                  <strong class="block text-xl text-gray-950 dark:text-white">{item.value}</strong>
-                  <span class="mt-1 block text-sm leading-relaxed text-muted dark:text-slate-300">{item.label}</span>
-                </div>
-              ))
-            }
-          </div>
-        </div>
+  <Hero2 tagline="IDA · Intelligent Document Analyzer">
+    <Fragment slot="title">
+      문서 데이터를<br />
+      <span class="text-accent">정량 근거로 분석</span>
+    </Fragment>
 
-        <div class="relative">
-          <div class="overflow-hidden rounded-lg border border-stone-200 dark:border-slate-800 bg-slate-950 shadow-xl">
-            <img
-              src={overviewScreen.src}
-              width={overviewScreen.width}
-              height={overviewScreen.height}
-              alt="MetaInsight 분석 결과 요약 대시보드"
-              class="aspect-[16/10] w-full object-cover object-top"
-              loading="eager"
-            />
-            <div class="grid grid-cols-3 border-t border-white/10 bg-slate-900 text-white">
-              <div class="p-3 sm:p-4">
-                <span class="block text-xs uppercase text-blue-200">Input</span>
-                <strong class="text-xs sm:text-sm">Records</strong>
-              </div>
-              <div class="p-3 sm:p-4 border-x border-white/10">
-                <span class="block text-xs uppercase text-blue-200">Engine</span>
-                <strong class="text-xs sm:text-sm">Scoring</strong>
-              </div>
-              <div class="p-3 sm:p-4">
-                <span class="block text-xs uppercase text-blue-200">Output</span>
-                <strong class="text-xs sm:text-sm">Insights</strong>
-              </div>
-            </div>
+    <Fragment slot="subtitle">
+      IDA는 MetaInsight의 제품 경험을 기반으로, 구조화된 문서·레코드 데이터에서 키워드 클러스터와 시계열 시그널을 찾고
+      분석 결과를 인사이트로 정리하는 문서 분석 AI 솔루션입니다.
+    </Fragment>
+
+    <Fragment slot="image">
+      <div class="overflow-hidden rounded-md border border-gray-200 dark:border-slate-700 bg-slate-950 shadow-lg">
+        <img
+          src={overviewScreen.src}
+          width={overviewScreen.width}
+          height={overviewScreen.height}
+          alt="MetaInsight 분석 결과 요약 대시보드"
+          class="aspect-[16/10] w-full object-cover object-top"
+          loading="eager"
+        />
+        <div class="grid grid-cols-3 border-t border-white/10 text-white">
+          <div class="p-4">
+            <span class="block text-xs uppercase text-blue-200">Input</span>
+            <strong class="text-sm">Records</strong>
+          </div>
+          <div class="p-4 border-x border-white/10">
+            <span class="block text-xs uppercase text-blue-200">Engine</span>
+            <strong class="text-sm">Scoring</strong>
+          </div>
+          <div class="p-4">
+            <span class="block text-xs uppercase text-blue-200">Output</span>
+            <strong class="text-sm">Insights</strong>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </Fragment>
+  </Hero2>
 
-  <section class="not-prose bg-stone-50 dark:bg-slate-900 py-14 md:py-20">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6">
-      <div class="max-w-3xl">
-        <p class="text-sm font-bold tracking-wide uppercase text-blue-700 dark:text-blue-300">Product Scope</p>
-        <h2 class="mt-3 text-3xl md:text-4xl font-bold tracking-tight dark:text-white">
-          문서·레코드 분석을 위한 핵심 기능
-        </h2>
-        <p class="mt-4 text-lg text-muted dark:text-slate-300">
-          IDA는 텍스트와 날짜 축이 정리된 문서·레코드 데이터를 기준으로 분석을 시작합니다. 업로드, 컬럼 매핑,
-          클러스터링, 정량 평가, 인사이트 생성까지 이어지는 흐름을 하나의 화면 경험으로 제공합니다.
-        </p>
-      </div>
+  <Features3
+    tagline="Product Scope"
+    title="문서·레코드 분석을 위한 핵심 기능"
+    subtitle="IDA는 텍스트와 날짜 축이 정리된 문서·레코드 데이터를 기준으로 분석을 시작합니다. 업로드, 컬럼 매핑, 클러스터링, 정량 평가, 인사이트 생성까지 이어지는 흐름을 하나의 화면 경험으로 제공합니다."
+    columns={3}
+    isDark
+    items={[
+      {
+        title: '문서·레코드 업로드',
+        description:
+          'CSV, Excel, Parquet 파일을 업로드하고 텍스트, 날짜, 금액, 그룹, 식별자 컬럼을 화면에서 확인하며 분석 조건을 구성합니다.',
+        icon: 'tabler:file-spreadsheet',
+      },
+      {
+        title: '키워드 클러스터링',
+        description:
+          '비슷한 키워드와 문서 항목을 자동으로 묶고, 각 클러스터가 시간에 따라 어떻게 변화하는지 정량적으로 비교합니다.',
+        icon: 'tabler:category-2',
+      },
+      {
+        title: '정량 근거 기반 인사이트',
+        description:
+          'C1 장기 트렌드, C2 모멘텀 유지, C3 최근 가속 기준을 바탕으로 등급과 점수를 산출하고 자연어 인사이트를 제공합니다.',
+        icon: 'tabler:report-analytics',
+      },
+    ]}
+  />
 
-      <div class="mt-10 grid md:grid-cols-3 gap-5">
+  <Steps
+    tagline="Analysis Workflow"
+    title="업로드부터 인사이트까지 이어지는 운용 흐름"
+    subtitle="사용자는 복잡한 코드 없이 분석 파일을 올리고, 자동 감지된 컬럼을 검토한 뒤 프리셋을 선택해 분석을 실행합니다. 결과는 요약 지표, 차트, 항목 상세, 자연어 인사이트로 나누어 확인합니다."
+    items={[
+      {
+        title: 'Upload',
+        description: '분석할 문서·레코드 데이터를 업로드하고 지원 형식을 확인합니다.',
+        icon: 'tabler:upload',
+      },
+      {
+        title: 'Map Columns',
+        description: '텍스트와 날짜 컬럼을 중심으로 분석에 필요한 필드를 매핑합니다.',
+        icon: 'tabler:columns',
+      },
+      {
+        title: 'Evaluate',
+        description: '키워드 군집을 만들고 트렌드 강도, 모멘텀, 최근 가속을 평가합니다.',
+        icon: 'tabler:wave-sine',
+      },
+      {
+        title: 'Review Insights',
+        description: '요약 지표, 상세 항목, AI 또는 템플릿 기반 인사이트를 검토합니다.',
+        icon: 'tabler:report-analytics',
+      },
+    ]}
+  />
+
+  <Features2
+    tagline="Signal Criteria"
+    title="정량 평가 엔진의 세 가지 기준"
+    subtitle="단순 키워드 빈도보다 중요한 것은 지속성, 현재성, 변화 속도입니다. IDA는 각 클러스터를 독립 기준으로 평가해 설명 가능한 점수와 등급으로 정리합니다."
+    columns={3}
+    items={[
+      {
+        title: 'C1 — 장기 트렌드',
+        description: '시간이 지나며 꾸준히 증가하는 클러스터인지 확인합니다.',
+        icon: 'tabler:trending-up',
+      },
+      {
+        title: 'C2 — 모멘텀 유지',
+        description: '최근 구간의 활동이 기준선보다 높은 상태를 유지하는지 봅니다.',
+        icon: 'tabler:activity',
+      },
+      {
+        title: 'C3 — 최근 가속',
+        description: '현재 시점에 가까워질수록 격차가 더 커지는지 평가합니다.',
+        icon: 'tabler:rocket',
+      },
+    ]}
+  />
+
+  <WidgetWrapper isDark containerClass="max-w-7xl mx-auto">
+    <Headline
+      tagline="Product Screens"
+      title="선택해서 보는 실제 화면"
+      subtitle="의사결정에 필요한 장면을 선별했습니다. 왼쪽에서 관심 기능을 선택하면 오른쪽에서 실제 화면과 핵심 의미를 바로 확인할 수 있습니다."
+      classes={{
+        container: 'text-center md:text-left rtl:md:text-right max-w-3xl',
+        title: 'text-3xl md:text-4xl font-bold tracking-tight',
+        subtitle: 'text-xl text-muted dark:text-slate-400',
+      }}
+    />
+
+    <div class="relative isolate grid gap-6 lg:grid-cols-[0.72fr_1.28fr]" data-ida-screens>
+      <div class="relative z-40 order-2 grid gap-3 sm:grid-cols-2 lg:order-1 lg:grid-cols-1 pointer-events-auto">
         {
-          capabilityItems.map((item) => (
-            <article class="rounded-lg border border-stone-200 dark:border-slate-800 bg-white dark:bg-slate-950 p-6">
-              <div class={`w-12 h-12 rounded-lg flex items-center justify-center ${item.tone}`}>
-                <Icon name={item.icon} class="w-7 h-7" />
-              </div>
-              <h3 class="mt-5 text-xl font-bold dark:text-white">{item.title}</h3>
-              <p class="mt-3 leading-relaxed text-muted dark:text-slate-300">{item.description}</p>
-            </article>
+          screenItems.map((item, index) => (
+            <button
+              type="button"
+              class:list={[
+                'group relative z-40 w-full cursor-pointer select-none overflow-hidden rounded-md border p-0 text-left transition bg-white dark:bg-slate-900 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary pointer-events-auto',
+                index === 1
+                  ? 'border-primary ring-1 ring-primary'
+                  : 'border-gray-200 dark:border-slate-700',
+              ]}
+              data-ida-screen-trigger
+              data-ida-active={index === 1 ? 'true' : 'false'}
+              data-ida-image={item.image.src}
+              data-ida-alt={item.alt}
+              data-ida-title={item.title}
+              data-ida-description={item.description}
+              aria-pressed={index === 1 ? 'true' : 'false'}
+            >
+              <span class="grid min-h-[84px] grid-cols-[96px_1fr]">
+                <span class="relative block bg-black">
+                  <img
+                    src={item.image.src}
+                    width={item.image.width}
+                    height={item.image.height}
+                    alt=""
+                    class="h-full w-full object-cover object-top opacity-80 transition group-hover:opacity-100"
+                    loading="lazy"
+                    aria-hidden="true"
+                  />
+                  <span class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/20">
+                    <span class="flex h-9 w-9 items-center justify-center rounded-full bg-white text-primary">
+                      <Icon name={item.icon} class="h-5 w-5" />
+                    </span>
+                  </span>
+                </span>
+                <span class="flex flex-col justify-center p-4">
+                  <span class="text-sm font-bold text-heading dark:text-white">{item.title}</span>
+                  <span class="mt-1 text-xs leading-relaxed text-muted dark:text-slate-400">{item.description}</span>
+                </span>
+              </span>
+            </button>
           ))
         }
       </div>
-    </div>
-  </section>
 
-  <section class="not-prose bg-white dark:bg-slate-950 py-14 md:py-20">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6">
-      <div class="grid lg:grid-cols-[0.8fr_1.2fr] gap-10 lg:gap-14 items-start">
-        <div>
-          <p class="text-sm font-bold tracking-wide uppercase text-blue-700 dark:text-blue-300">Analysis Workflow</p>
-          <h2 class="mt-3 text-3xl md:text-4xl font-bold tracking-tight dark:text-white">
-            업로드부터 인사이트까지 이어지는 운용 흐름
-          </h2>
-          <p class="mt-4 text-lg text-muted dark:text-slate-300">
-            사용자는 복잡한 코드 없이 분석 파일을 올리고, 자동 감지된 컬럼을 검토한 뒤 프리셋을 선택해 분석을
-            실행합니다. 결과는 요약 지표, 차트, 항목 상세, 자연어 인사이트로 나누어 확인합니다.
-          </p>
-          <div class="mt-8 grid sm:grid-cols-2 gap-4">
-            {
-              workflowItems.map((item) => (
-                <div class="rounded-lg border border-stone-200 dark:border-slate-800 bg-stone-50 dark:bg-slate-900 p-5">
-                  <span class="text-xs font-bold tracking-wide text-blue-700 dark:text-blue-300">{item.label}</span>
-                  <h3 class="mt-2 text-xl font-bold dark:text-white">{item.title}</h3>
-                  <p class="mt-2 text-sm leading-relaxed text-muted dark:text-slate-300">{item.description}</p>
-                </div>
-              ))
-            }
-          </div>
+      <article
+        class="relative z-10 order-1 overflow-hidden rounded-md border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg lg:order-2"
+      >
+        <div class="bg-black">
+          <img
+            src={initialScreen.image.src}
+            width={initialScreen.image.width}
+            height={initialScreen.image.height}
+            alt={initialScreen.alt}
+            class="aspect-[16/10] w-full object-cover object-top"
+            loading="eager"
+            data-ida-screen-image
+          />
         </div>
-
-        <div class="rounded-lg border border-stone-200 dark:border-slate-800 bg-stone-50 dark:bg-slate-900 p-6">
-          <div class="flex items-start gap-4 border-b border-stone-200 dark:border-slate-800 pb-6">
-            <div
-              class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-700 dark:bg-blue-950/50 dark:text-blue-300"
-            >
-              <Icon name="tabler:binary-tree-2" class="h-7 w-7" />
+        <div class="border-t border-gray-200 dark:border-slate-700 p-5 md:p-6">
+          <div class="flex flex-col gap-4 md:flex-row md:items-start">
+            <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-md bg-primary text-white">
+              <Icon name={initialScreen.icon} class="h-6 w-6" data-ida-screen-icon />
             </div>
-            <div>
-              <h3 class="text-2xl font-bold tracking-tight dark:text-white">정량 평가 엔진</h3>
-              <p class="mt-2 leading-relaxed text-muted dark:text-slate-300">
-                단순 키워드 빈도보다 중요한 것은 지속성, 현재성, 변화 속도입니다. IDA는 각 클러스터를 독립 기준으로
-                평가해 설명 가능한 점수와 등급으로 정리합니다.
+            <div class="min-w-0">
+              <h3 class="text-xl font-bold text-heading dark:text-white" data-ida-screen-heading>
+                {initialScreen.title}
+              </h3>
+              <p class="mt-2 leading-relaxed text-muted dark:text-slate-400" data-ida-screen-copy>
+                {initialScreen.description}
               </p>
             </div>
           </div>
-
-          <div class="mt-6 grid gap-3">
-            {
-              signalCriteria.map((item) => (
-                <div class="grid grid-cols-[64px_1fr] gap-4 rounded-lg border border-stone-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-950">
-                  <div class="flex h-14 w-14 items-center justify-center rounded-lg bg-blue-700 text-lg font-bold text-white">
-                    {item.title}
-                  </div>
-                  <div>
-                    <h4 class="font-bold dark:text-white">{item.label}</h4>
-                    <p class="mt-1 text-sm leading-relaxed text-muted dark:text-slate-300">{item.description}</p>
-                  </div>
-                </div>
-              ))
-            }
-          </div>
-
-          <div
-            class="mt-6 rounded-lg bg-white p-4 text-sm leading-relaxed text-muted dark:bg-slate-950 dark:text-slate-300"
-          >
-            결과 화면에서는 이 기준을 통과한 수, 종합 점수, 관련 키워드, 레코드 수를 함께 보여주어 분석자가 근거를
-            추적할 수 있게 합니다.
-          </div>
         </div>
-      </div>
+      </article>
     </div>
-  </section>
+  </WidgetWrapper>
 
-  <section class="not-prose bg-zinc-950 text-white py-14 md:py-20">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6">
-      <div class="max-w-3xl">
-        <p class="text-sm font-bold tracking-wide uppercase text-blue-300">Product Screens</p>
-        <h2 class="mt-3 text-3xl md:text-4xl font-bold tracking-tight">선택해서 보는 실제 화면</h2>
-        <p class="mt-4 text-lg text-slate-300">
-          의사결정에 필요한 장면을 선별했습니다. 왼쪽에서 관심 기능을 선택하면 오른쪽에서 실제 화면과 핵심 의미를 바로
-          확인할 수 있습니다.
-        </p>
-      </div>
-
-      <div class="relative isolate mt-10 grid gap-6 lg:grid-cols-[0.72fr_1.28fr]" data-ida-screens>
-        <div class="relative z-40 order-2 grid gap-3 sm:grid-cols-2 lg:order-1 lg:grid-cols-1 pointer-events-auto">
-          {
-            screenItems.map((item, index) => (
-              <button
-                type="button"
-                class:list={[
-                  'group relative z-40 w-full cursor-pointer select-none overflow-hidden rounded-lg border-[1px] p-0 text-left transition focus:outline-none focus:ring-2 focus:ring-blue-300 pointer-events-auto',
-                  index === 1 ? 'border-blue-300 bg-white/10' : 'border-white/10 bg-white/[0.04] hover:bg-white/[0.08]',
-                ]}
-                data-ida-screen-trigger
-                data-ida-active={index === 1 ? 'true' : 'false'}
-                data-ida-image={item.image.src}
-                data-ida-alt={item.alt}
-                data-ida-title={item.title}
-                data-ida-description={item.description}
-                aria-pressed={index === 1 ? 'true' : 'false'}
-              >
-                <span class="grid min-h-[84px] grid-cols-[96px_1fr]">
-                  <span class="relative block bg-black">
-                    <img
-                      src={item.image.src}
-                      width={item.image.width}
-                      height={item.image.height}
-                      alt=""
-                      class="h-full w-full object-cover object-top opacity-80 transition group-hover:opacity-100"
-                      loading="lazy"
-                      aria-hidden="true"
-                    />
-                    <span class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/20">
-                      <span class="flex h-9 w-9 items-center justify-center rounded-full bg-white/90 text-zinc-950">
-                        <Icon name={item.icon} class="h-5 w-5" />
-                      </span>
-                    </span>
-                  </span>
-                  <span class="flex flex-col justify-center p-4">
-                    <span class="text-sm font-bold text-white">{item.title}</span>
-                    <span class="mt-1 text-xs leading-relaxed text-slate-300">{item.description}</span>
-                  </span>
-                </span>
-              </button>
-            ))
-          }
-        </div>
-
-        <article
-          class="relative z-10 order-1 overflow-hidden rounded-lg border border-white/10 bg-white/[0.04] lg:order-2"
-        >
-          <div class="bg-black">
-            <img
-              src={initialScreen.image.src}
-              width={initialScreen.image.width}
-              height={initialScreen.image.height}
-              alt={initialScreen.alt}
-              class="aspect-[16/10] w-full object-cover object-top"
-              loading="eager"
-              data-ida-screen-image
-            />
-          </div>
-          <div class="border-t border-white/10 p-5 md:p-6">
-            <div class="flex flex-col gap-4 md:flex-row md:items-start">
-              <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-blue-300 text-zinc-950">
-                <Icon name={initialScreen.icon} class="h-6 w-6" data-ida-screen-icon />
-              </div>
-              <div class="min-w-0">
-                <h3 class="text-xl font-bold" data-ida-screen-heading>{initialScreen.title}</h3>
-                <p class="mt-2 leading-relaxed text-slate-300" data-ida-screen-copy>{initialScreen.description}</p>
-              </div>
-            </div>
-          </div>
-        </article>
-      </div>
-    </div>
-  </section>
-
-  <section class="not-prose bg-white dark:bg-slate-950 py-14 md:py-20">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6">
-      <div class="grid lg:grid-cols-[1fr_0.72fr] gap-10 lg:gap-14 items-center">
-        <div>
-          <p class="text-sm font-bold tracking-wide uppercase text-blue-700 dark:text-blue-300">
-            Operation & Expansion
-          </p>
-          <h2 class="mt-3 text-3xl md:text-4xl font-bold tracking-tight dark:text-white">
-            분석 엔진을 제품으로 운용하기 위한 기반
-          </h2>
-          <p class="mt-4 text-lg leading-relaxed text-muted dark:text-slate-300">
-            MetaInsight는 분석 엔진만이 아니라 계정, 프로젝트, 결과 저장, 내보내기, 모바일 대응 화면까지 포함한 제품형
-            구조를 갖추고 있습니다. IDA는 이 기반 위에서 기업 문서·규제·과제 데이터 분석 영역으로 확장됩니다.
-          </p>
-
-          <div class="mt-8 grid md:grid-cols-3 gap-4">
-            {
-              operationItems.map((item) => (
-                <article class="rounded-lg border border-stone-200 dark:border-slate-800 bg-stone-50 dark:bg-slate-900 p-5">
-                  <div class="w-11 h-11 rounded-lg bg-blue-50 dark:bg-blue-950/50 text-blue-700 dark:text-blue-300 flex items-center justify-center">
-                    <Icon name={item.icon} class="w-6 h-6" />
-                  </div>
-                  <h3 class="mt-4 text-lg font-bold dark:text-white">{item.title}</h3>
-                  <p class="mt-2 text-sm leading-relaxed text-muted dark:text-slate-300">{item.description}</p>
-                </article>
-              ))
-            }
-          </div>
-        </div>
-
-        <figure class="mx-auto w-full max-w-[320px]">
-          <div class="rounded-[2rem] border border-slate-800 bg-slate-950 p-2 shadow-xl shadow-slate-950/20">
-            <img
-              src={mobileScreen.src}
-              width={mobileScreen.width}
-              height={mobileScreen.height}
-              alt="MetaInsight 모바일 프로젝트 화면"
-              class="aspect-[1170/2532] w-full rounded-[1.5rem] object-cover object-top"
-              loading="eager"
-            />
-          </div>
-          <figcaption class="mt-4 text-center text-sm leading-relaxed text-muted dark:text-slate-300">
-            모바일 화면에서도 프로젝트 목록과 분석 진입 흐름을 확인할 수 있습니다.
-          </figcaption>
-        </figure>
-      </div>
-    </div>
-  </section>
+  <Content
+    isReversed
+    tagline="Operation & Expansion"
+    title="분석 엔진을 제품으로 운용하기 위한 기반"
+    items={[
+      {
+        title: 'SaaS 운용 구조',
+        description: 'JWT 인증, 프로젝트 단위 관리, 사용량 제한 등 SaaS 제품 운용에 필요한 기본 구조를 갖춥니다.',
+        icon: 'tabler:shield-check',
+      },
+      {
+        title: '도메인 확장',
+        description:
+          'R&D 과제, 특허, 리테일, 금융 리스크처럼 텍스트와 날짜 축이 있는 데이터로 분석 대상을 확장할 수 있습니다.',
+        icon: 'tabler:database-search',
+      },
+      {
+        title: '반복 탐색',
+        description: '국가, 분야, 기간, 프리셋 등 조건을 조정하며 같은 데이터에서 다른 관점의 시그널을 확인합니다.',
+        icon: 'tabler:refresh-dot',
+      },
+    ]}
+    image={{
+      src: mobileScreen,
+      alt: 'MetaInsight 모바일 프로젝트 화면',
+    }}
+  >
+    <Fragment slot="content">
+      <p class="text-lg leading-relaxed text-muted dark:text-slate-400">
+        MetaInsight는 분석 엔진만이 아니라 계정, 프로젝트, 결과 저장, 내보내기, 모바일 대응 화면까지 포함한 제품형 구조를
+        갖추고 있습니다. IDA는 이 기반 위에서 기업 문서·규제·과제 데이터 분석 영역으로 확장됩니다.
+      </p>
+    </Fragment>
+  </Content>
 
   <script is:inline data-astro-rerun>
     (() => {
@@ -485,10 +347,11 @@ const operationItems = [
           const isActive = button === selectedButton;
           button.setAttribute('data-ida-active', String(isActive));
           button.setAttribute('aria-pressed', String(isActive));
-          button.classList.toggle('border-blue-300', isActive);
-          button.classList.toggle('bg-white/10', isActive);
-          button.classList.toggle('border-white/10', !isActive);
-          button.classList.toggle('bg-white/[0.04]', !isActive);
+          button.classList.toggle('border-primary', isActive);
+          button.classList.toggle('ring-1', isActive);
+          button.classList.toggle('ring-primary', isActive);
+          button.classList.toggle('border-gray-200', !isActive);
+          button.classList.toggle('dark:border-slate-700', !isActive);
         });
 
         const nextImage = selectedButton.getAttribute('data-ida-image');

--- a/src/pages/solutions/mvi.astro
+++ b/src/pages/solutions/mvi.astro
@@ -3,7 +3,6 @@ import { Icon } from 'astro-icon/components';
 
 import Layout from '~/layouts/PageLayout.astro';
 import Header from '~/components/widgets/Header.astro';
-import CallToAction from '~/components/widgets/CallToAction.astro';
 
 import { headerData } from '~/navigation';
 
@@ -381,22 +380,6 @@ const initialDemo = demoItems[0];
       </div>
     </div>
   </section>
-
-  <CallToAction
-    actions={[
-      {
-        variant: 'primary',
-        text: '도입 문의',
-        href: '/contact',
-        icon: 'tabler:message-circle',
-      },
-    ]}
-  >
-    <Fragment slot="title">제조 현장의 데이터 부족 문제를 MVI로 해결하세요.</Fragment>
-    <Fragment slot="subtitle">
-      소량 양품 데이터 기반 학습, GenAI 증강, 불량 유형 분류를 하나의 운용 흐름으로 제공합니다.
-    </Fragment>
-  </CallToAction>
 
   <script is:inline>
     const findDemoTriggerFromPoint = (root, clientX, clientY) => {

--- a/src/pages/solutions/mvi.astro
+++ b/src/pages/solutions/mvi.astro
@@ -180,9 +180,7 @@ const initialDemo = demoItems[0];
               type="button"
               class:list={[
                 'group relative z-40 w-full cursor-pointer select-none overflow-hidden rounded-md border p-0 text-left transition bg-white dark:bg-slate-900 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary pointer-events-auto',
-                index === 0
-                  ? 'border-primary ring-1 ring-primary'
-                  : 'border-gray-200 dark:border-slate-700',
+                index === 0 ? 'border-primary ring-1 ring-primary' : 'border-gray-200 dark:border-slate-700',
               ]}
               data-demo-trigger
               data-demo-active={index === 0 ? 'true' : 'false'}
@@ -238,7 +236,9 @@ const initialDemo = demoItems[0];
             </div>
             <div class="min-w-0 flex-1">
               <h3 class="text-xl font-bold text-heading dark:text-white" data-demo-heading>{initialDemo.title}</h3>
-              <p class="mt-2 leading-relaxed text-muted dark:text-slate-400" data-demo-copy>{initialDemo.description}</p>
+              <p class="mt-2 leading-relaxed text-muted dark:text-slate-400" data-demo-copy>
+                {initialDemo.description}
+              </p>
             </div>
             <button
               type="button"
@@ -288,8 +288,8 @@ const initialDemo = demoItems[0];
     <Fragment slot="content">
       <p class="text-lg leading-relaxed text-muted dark:text-slate-400">
         MVI는 대화형 UI를 통해 증강, 학습, 검출, 분류 과정의 튜닝과 조율을 AI 에이전트가 대신 처리하는 방향으로
-        고도화됩니다. 운용자는 전문 파라미터를 직접 다루기보다 “검출 민감도를 높여줘”, “이 유형을 별도 불량군으로 묶어줘”
-        같은 자연어 요청으로 검사 품질을 개선할 수 있습니다.
+        고도화됩니다. 운용자는 전문 파라미터를 직접 다루기보다 “검출 민감도를 높여줘”, “이 유형을 별도 불량군으로
+        묶어줘” 같은 자연어 요청으로 검사 품질을 개선할 수 있습니다.
       </p>
     </Fragment>
   </Content>

--- a/src/pages/solutions/mvi.astro
+++ b/src/pages/solutions/mvi.astro
@@ -1,8 +1,13 @@
 ---
-import { Icon } from 'astro-icon/components';
-
 import Layout from '~/layouts/PageLayout.astro';
 import Header from '~/components/widgets/Header.astro';
+import Hero2 from '~/components/widgets/Hero2.astro';
+import Features3 from '~/components/widgets/Features3.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import Content from '~/components/widgets/Content.astro';
+import WidgetWrapper from '~/components/ui/WidgetWrapper.astro';
+import Headline from '~/components/ui/Headline.astro';
+import { Icon } from 'astro-icon/components';
 
 import { headerData } from '~/navigation';
 
@@ -18,58 +23,6 @@ const metadata = {
   description:
     'MVI는 소량의 양품 데이터만으로 제조 불량을 검출하고, GenAI 증강과 결함 분류를 통해 데이터가 부족한 현장에서도 운용 가능한 제조 특화 Vision AI 솔루션입니다.',
 };
-
-const capabilityItems = [
-  {
-    title: '소량 양품 기반 이상탐지',
-    description:
-      '대량의 불량 데이터를 기다리지 않고, 제조 현장에서 확보하기 쉬운 양품 데이터 중심으로 AI를 학습해 불량 가능성과 영역을 검출합니다.',
-    icon: 'tabler:scan-eye',
-    tone: 'text-emerald-600 bg-emerald-50 dark:bg-emerald-950/40 dark:text-emerald-300',
-  },
-  {
-    title: 'GenAI 데이터 증강',
-    description:
-      '양품과 불량 샘플, 마스킹 정보를 바탕으로 부족한 검사 이미지를 추가 생성하여 초기 학습과 성능 개선에 필요한 데이터 공백을 줄입니다.',
-    icon: 'tabler:sparkles',
-    tone: 'text-amber-600 bg-amber-50 dark:bg-amber-950/40 dark:text-amber-300',
-  },
-  {
-    title: '불량 유형 클러스터링',
-    description:
-      '검출 결과의 특징을 추출하고 유사도를 기준으로 군집화하여, 반복되는 불량 패턴을 유형별로 나누고 현장 개선에 연결합니다.',
-    icon: 'tabler:category-2',
-    tone: 'text-rose-600 bg-rose-50 dark:bg-rose-950/40 dark:text-rose-300',
-  },
-];
-
-const pipelineItems = [
-  {
-    label: '01',
-    title: 'Load',
-    description: '운용자가 검사 대상 이미지와 기준 데이터를 불러와 현장 품목에 맞는 검사 프로젝트를 구성합니다.',
-  },
-  {
-    label: '02',
-    title: 'Augment',
-    description: '부족한 양품/불량 데이터를 생성형 AI로 증강하여 학습 가능한 데이터셋을 빠르게 보강합니다.',
-  },
-  {
-    label: '03',
-    title: 'Train',
-    description: '양품 중심 데이터와 증강 데이터를 이용해 제조 도메인에 최적화된 이상탐지 모델을 학습합니다.',
-  },
-  {
-    label: '04',
-    title: 'Inspect',
-    description: '실제 검사 이미지에서 불량 여부, 의심 영역, 신뢰도 등 운용에 필요한 메타데이터를 산출합니다.',
-  },
-  {
-    label: '05',
-    title: 'Classify',
-    description: '검출된 결함을 특징 유사도에 따라 분류하여 반복 불량과 공정 이슈를 파악할 수 있게 합니다.',
-  },
-];
 
 const demoItems = [
   {
@@ -103,283 +56,243 @@ const initialDemo = demoItems[0];
     <Header {...headerData} isSticky showToggleTheme />
   </Fragment>
 
-  <section class="relative not-prose overflow-hidden bg-white dark:bg-slate-950">
-    <div class="relative max-w-7xl mx-auto px-4 sm:px-6">
-      <div
-        class="grid lg:grid-cols-[0.95fr_1.05fr] gap-10 lg:gap-14 items-center py-12 md:py-16 lg:min-h-[calc(100vh-88px)]"
-      >
-        <div>
-          <p class="text-sm font-bold tracking-wide uppercase text-emerald-700 dark:text-emerald-300">
-            MVI · Meta Vision AI
-          </p>
-          <h1 class="mt-4 text-4xl md:text-6xl font-bold leading-tight tracking-tight font-heading dark:text-white">
-            데이터가 부족한 제조 현장을 위한<br class="hidden md:block" />
-            <span class="text-emerald-700 dark:text-emerald-300">AI 비전 불량 검출</span>
-          </h1>
-          <p class="mt-6 max-w-2xl text-lg md:text-xl leading-relaxed text-muted dark:text-slate-300">
-            MVI는 소량의 양품 데이터만으로 이상탐지 모델을 학습하고, GenAI 증강과 결함 분류를 결합해 제조 시설 운용자가
-            직접 관리할 수 있는 제조 특화 Vision AI 솔루션입니다.
-          </p>
-          <div class="mt-8 grid sm:grid-cols-3 gap-3 max-w-2xl">
-            <div class="border border-stone-200 dark:border-slate-800 p-4 rounded-lg bg-white dark:bg-slate-900">
-              <strong class="block text-2xl text-gray-950 dark:text-white">소량</strong>
-              <span class="text-sm text-muted">양품 데이터 중심 학습</span>
-            </div>
-            <div class="border border-stone-200 dark:border-slate-800 p-4 rounded-lg bg-white dark:bg-slate-900">
-              <strong class="block text-2xl text-gray-950 dark:text-white">GenAI</strong>
-              <span class="text-sm text-muted">양품/불량 데이터 증강</span>
-            </div>
-            <div class="border border-stone-200 dark:border-slate-800 p-4 rounded-lg bg-white dark:bg-slate-900">
-              <strong class="block text-2xl text-gray-950 dark:text-white">분류</strong>
-              <span class="text-sm text-muted">불량 유형별 군집화</span>
-            </div>
-          </div>
-        </div>
+  <Hero2 tagline="MVI · Meta Vision AI">
+    <Fragment slot="title">
+      데이터가 부족한 제조 현장을 위한<br />
+      <span class="text-accent">AI 비전 불량 검출</span>
+    </Fragment>
 
-        <div class="relative">
-          <div
-            class="relative overflow-hidden rounded-lg border border-stone-200 dark:border-slate-800 bg-slate-950 shadow-xl"
-          >
-            <video
-              class="relative z-10 aspect-video w-full object-cover pointer-events-auto"
-              src={inspectVideo}
-              poster={inspectThumbnail.src}
-              autoplay
-              loop
-              muted
-              playsinline
-              controls
-              data-hero-video
-              preload="metadata"
-              aria-label="MVI 불량 검출 시연 영상"></video>
-            <div class="grid grid-cols-3 border-t border-white/10 bg-slate-900 text-white">
-              <div class="p-4">
-                <span class="block text-xs uppercase text-emerald-200">Stage</span>
-                <strong class="text-sm">Inspection</strong>
-              </div>
-              <div class="p-4 border-x border-white/10">
-                <span class="block text-xs uppercase text-emerald-200">Mode</span>
-                <strong class="text-sm">Anomaly Detection</strong>
-              </div>
-              <div class="p-4">
-                <span class="block text-xs uppercase text-emerald-200">Output</span>
-                <strong class="text-sm">Defect Metadata</strong>
-              </div>
-            </div>
+    <Fragment slot="subtitle">
+      MVI는 소량의 양품 데이터만으로 이상탐지 모델을 학습하고, GenAI 증강과 결함 분류를 결합해 제조 시설 운용자가 직접
+      관리할 수 있는 제조 특화 Vision AI 솔루션입니다.
+    </Fragment>
+
+    <Fragment slot="image">
+      <div class="overflow-hidden rounded-md border border-gray-200 dark:border-slate-700 bg-slate-950 shadow-lg">
+        <video
+          class="aspect-video w-full object-cover"
+          src={inspectVideo}
+          poster={inspectThumbnail.src}
+          autoplay
+          loop
+          muted
+          playsinline
+          controls
+          preload="metadata"
+          data-hero-video
+          aria-label="MVI 불량 검출 시연 영상"></video>
+        <div class="grid grid-cols-3 border-t border-white/10 text-white">
+          <div class="p-4">
+            <span class="block text-xs uppercase text-blue-200">Stage</span>
+            <strong class="text-sm">Inspection</strong>
+          </div>
+          <div class="p-4 border-x border-white/10">
+            <span class="block text-xs uppercase text-blue-200">Mode</span>
+            <strong class="text-sm">Anomaly Detection</strong>
+          </div>
+          <div class="p-4">
+            <span class="block text-xs uppercase text-blue-200">Output</span>
+            <strong class="text-sm">Defect Metadata</strong>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </Fragment>
+  </Hero2>
 
-  <section class="not-prose bg-stone-50 dark:bg-slate-900 py-14 md:py-20">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6">
-      <div class="max-w-3xl">
-        <p class="text-sm font-bold tracking-wide uppercase text-emerald-700 dark:text-emerald-300">
-          Core Capabilities
-        </p>
-        <h2 class="mt-3 text-3xl md:text-4xl font-bold tracking-tight dark:text-white">
-          불량 데이터가 충분하지 않아도 시작할 수 있는 검사 체계
-        </h2>
-        <p class="mt-4 text-lg text-muted dark:text-slate-300">
-          MVI는 데이터 수집, 증강, 학습, 검출, 분류를 하나의 현장 운용 흐름으로 묶어 AI 전문 인력 없이도 제조 품질
-          검사를 반복 개선할 수 있게 합니다.
-        </p>
-      </div>
+  <Features3
+    tagline="Core Capabilities"
+    title="불량 데이터가 충분하지 않아도 시작할 수 있는 검사 체계"
+    subtitle="MVI는 데이터 수집, 증강, 학습, 검출, 분류를 하나의 현장 운용 흐름으로 묶어 AI 전문 인력 없이도 제조 품질 검사를 반복 개선할 수 있게 합니다."
+    columns={3}
+    isDark
+    items={[
+      {
+        title: '소량 양품 기반 이상탐지',
+        description:
+          '대량의 불량 데이터를 기다리지 않고, 제조 현장에서 확보하기 쉬운 양품 데이터 중심으로 AI를 학습해 불량 가능성과 영역을 검출합니다.',
+        icon: 'tabler:scan-eye',
+      },
+      {
+        title: 'GenAI 데이터 증강',
+        description:
+          '양품과 불량 샘플, 마스킹 정보를 바탕으로 부족한 검사 이미지를 추가 생성하여 초기 학습과 성능 개선에 필요한 데이터 공백을 줄입니다.',
+        icon: 'tabler:sparkles',
+      },
+      {
+        title: '불량 유형 클러스터링',
+        description:
+          '검출 결과의 특징을 추출하고 유사도를 기준으로 군집화하여, 반복되는 불량 패턴을 유형별로 나누고 현장 개선에 연결합니다.',
+        icon: 'tabler:category-2',
+      },
+    ]}
+  />
 
-      <div class="mt-10 grid md:grid-cols-3 gap-5">
+  <Steps
+    title="현장 운용자 중심의 MVI 파이프라인"
+    tagline="Operating Pipeline"
+    subtitle="품목 변경이나 데이터 부족이 발생해도 운용자가 GUI에서 데이터를 보강하고 모델을 다시 학습시키며, 검출 결과를 유형별로 관리하는 흐름을 제공합니다."
+    items={[
+      {
+        title: 'Load',
+        description: '운용자가 검사 대상 이미지와 기준 데이터를 불러와 현장 품목에 맞는 검사 프로젝트를 구성합니다.',
+        icon: 'tabler:upload',
+      },
+      {
+        title: 'Augment',
+        description: '부족한 양품/불량 데이터를 생성형 AI로 증강하여 학습 가능한 데이터셋을 빠르게 보강합니다.',
+        icon: 'tabler:sparkles',
+      },
+      {
+        title: 'Train',
+        description: '양품 중심 데이터와 증강 데이터를 이용해 제조 도메인에 최적화된 이상탐지 모델을 학습합니다.',
+        icon: 'tabler:brain',
+      },
+      {
+        title: 'Inspect',
+        description: '실제 검사 이미지에서 불량 여부, 의심 영역, 신뢰도 등 운용에 필요한 메타데이터를 산출합니다.',
+        icon: 'tabler:scan-eye',
+      },
+      {
+        title: 'Classify',
+        description: '검출된 결함을 특징 유사도에 따라 분류하여 반복 불량과 공정 이슈를 파악할 수 있게 합니다.',
+        icon: 'tabler:category-2',
+      },
+    ]}
+  />
+
+  <WidgetWrapper isDark containerClass="max-w-7xl mx-auto">
+    <Headline
+      tagline="Product Demo"
+      title="실제 시연 화면으로 보는 주요 기능"
+      subtitle="불량 검출과 데이터 증강 중심의 제품 운용 과정을 영상으로 확인할 수 있습니다."
+      classes={{
+        container: 'text-center md:text-left rtl:md:text-right max-w-3xl',
+        title: 'text-3xl md:text-4xl font-bold tracking-tight',
+        subtitle: 'text-xl text-muted dark:text-slate-400',
+      }}
+    />
+
+    <div class="relative isolate grid lg:grid-cols-[0.72fr_1.28fr] gap-6 lg:gap-8" data-mvi-demo>
+      <div class="relative z-40 order-2 lg:order-1 grid sm:grid-cols-2 lg:grid-cols-1 gap-3 pointer-events-auto">
         {
-          capabilityItems.map((item) => (
-            <article class="rounded-lg border border-stone-200 dark:border-slate-800 bg-white dark:bg-slate-950 p-6">
-              <div class={`w-12 h-12 rounded-lg flex items-center justify-center ${item.tone}`}>
-                <Icon name={item.icon} class="w-7 h-7" />
-              </div>
-              <h3 class="mt-5 text-xl font-bold dark:text-white">{item.title}</h3>
-              <p class="mt-3 leading-relaxed text-muted dark:text-slate-300">{item.description}</p>
-            </article>
+          demoItems.map((item, index) => (
+            <button
+              type="button"
+              class:list={[
+                'group relative z-40 w-full cursor-pointer select-none overflow-hidden rounded-md border p-0 text-left transition bg-white dark:bg-slate-900 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary pointer-events-auto',
+                index === 0
+                  ? 'border-primary ring-1 ring-primary'
+                  : 'border-gray-200 dark:border-slate-700',
+              ]}
+              data-demo-trigger
+              data-demo-active={index === 0 ? 'true' : 'false'}
+              data-demo-video={item.video}
+              data-demo-poster={item.poster.src}
+              data-demo-title={item.title}
+              data-demo-description={item.description}
+              aria-pressed={index === 0 ? 'true' : 'false'}
+            >
+              <span class="grid grid-cols-[112px_1fr] min-h-[88px]">
+                <span class="relative block bg-black">
+                  <img
+                    class="h-full w-full object-cover opacity-90 transition group-hover:opacity-100"
+                    src={item.poster.src}
+                    alt={`${item.title} 썸네일`}
+                    loading="lazy"
+                    draggable="false"
+                  />
+                  <span class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/20">
+                    <span class="flex h-9 w-9 items-center justify-center rounded-full bg-white text-primary">
+                      <Icon name={item.icon} class="h-5 w-5" />
+                    </span>
+                  </span>
+                </span>
+                <span class="flex flex-col justify-center p-4">
+                  <span class="text-sm font-bold text-heading dark:text-white">{item.title}</span>
+                  <span class="mt-1 text-xs leading-relaxed text-muted dark:text-slate-400">{item.description}</span>
+                </span>
+              </span>
+            </button>
           ))
         }
       </div>
-    </div>
-  </section>
 
-  <section class="not-prose bg-white dark:bg-slate-950 py-14 md:py-20">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6">
-      <div class="grid lg:grid-cols-[0.85fr_1.15fr] gap-10 lg:gap-14">
-        <div>
-          <p class="text-sm font-bold tracking-wide uppercase text-emerald-700 dark:text-emerald-300">
-            Operating Pipeline
-          </p>
-          <h2 class="mt-3 text-3xl md:text-4xl font-bold tracking-tight dark:text-white">
-            현장 운용자 중심의 MVI 파이프라인
-          </h2>
-          <p class="mt-4 text-lg text-muted dark:text-slate-300">
-            품목 변경이나 데이터 부족이 발생해도 운용자가 GUI에서 데이터를 보강하고 모델을 다시 학습시키며, 검출 결과를
-            유형별로 관리하는 흐름을 제공합니다.
-          </p>
+      <article
+        class="relative z-10 order-1 lg:order-2 overflow-hidden rounded-md border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg"
+      >
+        <div class="relative z-20 bg-black pointer-events-auto" data-demo-player-wrap>
+          <video
+            class="relative z-20 aspect-video w-full bg-black object-contain pointer-events-auto"
+            src={initialDemo.video}
+            poster={initialDemo.poster.src}
+            controls
+            playsinline
+            preload="metadata"
+            data-demo-player
+            aria-label={`MVI ${initialDemo.title} 시연 영상`}></video>
         </div>
-
-        <div class="grid sm:grid-cols-2 gap-4">
-          {
-            pipelineItems.map((item) => (
-              <div class="rounded-lg border border-stone-200 dark:border-slate-800 p-5 bg-stone-50 dark:bg-slate-900">
-                <span class="text-xs font-bold tracking-wide text-emerald-700 dark:text-emerald-300">{item.label}</span>
-                <h3 class="mt-2 text-xl font-bold dark:text-white">{item.title}</h3>
-                <p class="mt-2 text-sm leading-relaxed text-muted dark:text-slate-300">{item.description}</p>
-              </div>
-            ))
-          }
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section class="not-prose bg-zinc-950 text-white py-14 md:py-20">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6">
-      <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-6">
-        <div class="max-w-3xl">
-          <p class="text-sm font-bold tracking-wide uppercase text-emerald-300">Product Demo</p>
-          <h2 class="mt-3 text-3xl md:text-4xl font-bold tracking-tight">실제 시연 화면으로 보는 주요 기능</h2>
-          <p class="mt-4 text-lg text-slate-300">
-            불량 검출과 데이터 증강 중심의 제품 운용 과정을 영상으로 확인할 수 있습니다.
-          </p>
-        </div>
-      </div>
-
-      <div class="relative isolate mt-10 grid lg:grid-cols-[0.72fr_1.28fr] gap-6 lg:gap-8" data-mvi-demo>
-        <div class="relative z-40 order-2 lg:order-1 grid sm:grid-cols-2 lg:grid-cols-1 gap-3 pointer-events-auto">
-          {
-            demoItems.map((item, index) => (
-              <button
-                type="button"
-                class:list={[
-                  'group relative z-40 w-full cursor-pointer select-none overflow-hidden rounded-lg border p-0 text-left transition bg-white/[0.04] hover:bg-white/[0.08] focus:outline-none focus:ring-2 focus:ring-emerald-300 pointer-events-auto',
-                  index === 0 ? 'border-emerald-300 bg-white/10' : 'border-white/10',
-                ]}
-                data-demo-trigger
-                data-demo-active={index === 0 ? 'true' : 'false'}
-                data-demo-video={item.video}
-                data-demo-poster={item.poster.src}
-                data-demo-title={item.title}
-                data-demo-description={item.description}
-                aria-pressed={index === 0 ? 'true' : 'false'}
-              >
-                <span class="grid grid-cols-[112px_1fr] min-h-[88px]">
-                  <span class="relative block bg-black">
-                    <img
-                      class="h-full w-full object-cover opacity-90 transition group-hover:opacity-100"
-                      src={item.poster.src}
-                      alt={`${item.title} 썸네일`}
-                      loading="lazy"
-                      draggable="false"
-                    />
-                    <span class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/20">
-                      <span class="flex h-9 w-9 items-center justify-center rounded-full bg-white/90 text-zinc-950">
-                        <Icon name={item.icon} class="h-5 w-5" />
-                      </span>
-                    </span>
-                  </span>
-                  <span class="flex flex-col justify-center p-4">
-                    <span class="text-sm font-bold text-white">{item.title}</span>
-                    <span class="mt-1 text-xs leading-relaxed text-slate-300">{item.description}</span>
-                  </span>
-                </span>
-              </button>
-            ))
-          }
-        </div>
-
-        <article
-          class="relative z-10 order-1 lg:order-2 overflow-hidden rounded-lg border border-white/10 bg-white/[0.04]"
-        >
-          <div class="relative z-20 bg-black pointer-events-auto" data-demo-player-wrap>
-            <video
-              class="relative z-20 aspect-video w-full bg-black object-contain pointer-events-auto"
-              src={initialDemo.video}
-              poster={initialDemo.poster.src}
-              controls
-              playsinline
-              preload="metadata"
-              data-demo-player
-              aria-label={`MVI ${initialDemo.title} 시연 영상`}></video>
-          </div>
-          <div class="border-t border-white/10 p-5 md:p-6">
-            <div class="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
-              <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-emerald-300 text-zinc-950">
-                <Icon name="tabler:player-play" class="h-6 w-6" />
-              </div>
-              <div class="min-w-0 flex-1">
-                <h3 class="text-xl font-bold" data-demo-heading>{initialDemo.title}</h3>
-                <p class="mt-2 leading-relaxed text-slate-300" data-demo-copy>{initialDemo.description}</p>
-              </div>
-              <button
-                type="button"
-                class="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg bg-emerald-300 px-4 py-3 text-sm font-bold text-zinc-950 transition hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-300 focus:ring-offset-2 focus:ring-offset-zinc-950"
-                data-demo-play
-              >
-                <Icon name="tabler:player-play-filled" class="h-5 w-5" />
-                재생
-              </button>
+        <div class="border-t border-gray-200 dark:border-slate-700 p-5 md:p-6">
+          <div class="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
+            <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-md bg-primary text-white">
+              <Icon name="tabler:player-play" class="h-6 w-6" />
             </div>
-          </div>
-        </article>
-      </div>
-    </div>
-  </section>
-
-  <section class="not-prose bg-white dark:bg-slate-950 py-14 md:py-20">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6">
-      <div class="grid lg:grid-cols-2 gap-10 lg:gap-14 items-center">
-        <div>
-          <p class="text-sm font-bold tracking-wide uppercase text-emerald-700 dark:text-emerald-300">
-            Next Capability
-          </p>
-          <h2 class="mt-3 text-3xl md:text-4xl font-bold tracking-tight dark:text-white">
-            향후 도입: 제조 운용자를 위한 AI 에이전트
-          </h2>
-          <p class="mt-4 text-lg leading-relaxed text-muted dark:text-slate-300">
-            MVI는 대화형 UI를 통해 증강, 학습, 검출, 분류 과정의 튜닝과 조율을 AI 에이전트가 대신 처리하는 방향으로
-            고도화됩니다. 운용자는 전문 파라미터를 직접 다루기보다 “검출 민감도를 높여줘”, “이 유형을 별도 불량군으로
-            묶어줘” 같은 자연어 요청으로 검사 품질을 개선할 수 있습니다.
-          </p>
-        </div>
-
-        <div class="rounded-lg border border-stone-200 dark:border-slate-800 bg-stone-50 dark:bg-slate-900 p-6">
-          <div class="flex items-start gap-4 border-b border-stone-200 dark:border-slate-800 pb-5">
-            <div
-              class="w-11 h-11 rounded-lg bg-emerald-100 dark:bg-emerald-950/60 text-emerald-700 dark:text-emerald-300 flex items-center justify-center"
+            <div class="min-w-0 flex-1">
+              <h3 class="text-xl font-bold text-heading dark:text-white" data-demo-heading>{initialDemo.title}</h3>
+              <p class="mt-2 leading-relaxed text-muted dark:text-slate-400" data-demo-copy>{initialDemo.description}</p>
+            </div>
+            <button
+              type="button"
+              class="inline-flex shrink-0 items-center justify-center gap-2 rounded-md bg-primary px-4 py-3 text-sm font-bold text-white transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+              data-demo-play
             >
-              <Icon name="tabler:message-chatbot" class="w-7 h-7" />
-            </div>
-            <div>
-              <h3 class="text-xl font-bold dark:text-white">Conversational Tuning</h3>
-              <p class="mt-2 text-muted dark:text-slate-300">
-                증강 조건, 학습 데이터 구성, 검출 임계값, 분류 기준을 대화형 인터페이스로 조율합니다.
-              </p>
-            </div>
-          </div>
-          <div class="mt-5 grid sm:grid-cols-2 gap-4 text-sm">
-            <div class="rounded-lg bg-white dark:bg-slate-950 p-4 border border-stone-200 dark:border-slate-800">
-              <strong class="block dark:text-white">Human-in-the-Loop</strong>
-              <span class="mt-2 block text-muted dark:text-slate-300">운용자 피드백을 모델 개선 루프로 연결</span>
-            </div>
-            <div class="rounded-lg bg-white dark:bg-slate-950 p-4 border border-stone-200 dark:border-slate-800">
-              <strong class="block dark:text-white">No-Code Operation</strong>
-              <span class="mt-2 block text-muted dark:text-slate-300">AI 전문 지식 없이 검사 조건을 관리</span>
-            </div>
-            <div class="rounded-lg bg-white dark:bg-slate-950 p-4 border border-stone-200 dark:border-slate-800">
-              <strong class="block dark:text-white">Adaptive Inspection</strong>
-              <span class="mt-2 block text-muted dark:text-slate-300">품목 변경과 현장 편차에 빠르게 대응</span>
-            </div>
-            <div class="rounded-lg bg-white dark:bg-slate-950 p-4 border border-stone-200 dark:border-slate-800">
-              <strong class="block dark:text-white">Traceable Decision</strong>
-              <span class="mt-2 block text-muted dark:text-slate-300">검출 결과와 분류 근거를 현장 데이터로 축적</span>
-            </div>
+              <Icon name="tabler:player-play-filled" class="h-5 w-5" />
+              재생
+            </button>
           </div>
         </div>
-      </div>
+      </article>
     </div>
-  </section>
+  </WidgetWrapper>
+
+  <Content
+    isReversed
+    tagline="Next Capability"
+    title="향후 도입: 제조 운용자를 위한 AI 에이전트"
+    items={[
+      {
+        title: 'Human-in-the-Loop',
+        description: '운용자 피드백을 모델 개선 루프로 연결합니다.',
+        icon: 'tabler:user-check',
+      },
+      {
+        title: 'No-Code Operation',
+        description: 'AI 전문 지식 없이 검사 조건을 관리합니다.',
+        icon: 'tabler:keyboard-off',
+      },
+      {
+        title: 'Adaptive Inspection',
+        description: '품목 변경과 현장 편차에 빠르게 대응합니다.',
+        icon: 'tabler:adjustments',
+      },
+      {
+        title: 'Traceable Decision',
+        description: '검출 결과와 분류 근거를 현장 데이터로 축적합니다.',
+        icon: 'tabler:history',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?auto=format&fit=crop&w=2070&q=80',
+      alt: 'AI 에이전트 인터페이스',
+    }}
+  >
+    <Fragment slot="content">
+      <p class="text-lg leading-relaxed text-muted dark:text-slate-400">
+        MVI는 대화형 UI를 통해 증강, 학습, 검출, 분류 과정의 튜닝과 조율을 AI 에이전트가 대신 처리하는 방향으로
+        고도화됩니다. 운용자는 전문 파라미터를 직접 다루기보다 “검출 민감도를 높여줘”, “이 유형을 별도 불량군으로 묶어줘”
+        같은 자연어 요청으로 검사 품질을 개선할 수 있습니다.
+      </p>
+    </Fragment>
+  </Content>
 
   <script is:inline>
     const findDemoTriggerFromPoint = (root, clientX, clientY) => {
@@ -444,9 +357,11 @@ const initialDemo = demoItems[0];
         const isActive = button === selectedButton;
         button.setAttribute('data-demo-active', String(isActive));
         button.setAttribute('aria-pressed', String(isActive));
-        button.classList.toggle('border-emerald-300', isActive);
-        button.classList.toggle('border-white/10', !isActive);
-        button.classList.toggle('bg-white/10', isActive);
+        button.classList.toggle('border-primary', isActive);
+        button.classList.toggle('ring-1', isActive);
+        button.classList.toggle('ring-primary', isActive);
+        button.classList.toggle('border-gray-200', !isActive);
+        button.classList.toggle('dark:border-slate-700', !isActive);
       });
 
       const nextVideo = selectedButton.getAttribute('data-demo-video');

--- a/src/pages/solutions/strategy.astro
+++ b/src/pages/solutions/strategy.astro
@@ -6,7 +6,6 @@ import Hero2 from '~/components/widgets/Hero2.astro';
 import Content from '~/components/widgets/Content.astro';
 import Steps from '~/components/widgets/Steps.astro';
 import Features2 from '~/components/widgets/Features2.astro';
-import CallToAction from '~/components/widgets/CallToAction.astro';
 
 import { headerData } from '~/navigation';
 
@@ -139,16 +138,4 @@ const metadata = {
     ]}
   />
 
-  <CallToAction
-    actions={[
-      {
-        variant: 'primary',
-        text: 'Partner with Us',
-        href: '/contact',
-      },
-    ]}
-  >
-    <Fragment slot="title"> Join the AX 2035 Journey </Fragment>
-    <Fragment slot="subtitle"> MetaIntelligence와 함께 산업 지능화의 미래를 앞당기세요. </Fragment>
-  </CallToAction>
 </Layout>

--- a/src/pages/solutions/strategy.astro
+++ b/src/pages/solutions/strategy.astro
@@ -137,5 +137,4 @@ const metadata = {
       },
     ]}
   />
-
 </Layout>

--- a/src/pages/tech/core-tech.astro
+++ b/src/pages/tech/core-tech.astro
@@ -4,7 +4,6 @@ import Layout from '~/layouts/PageLayout.astro';
 import Header from '~/components/widgets/Header.astro';
 import Hero2 from '~/components/widgets/Hero2.astro';
 import Content from '~/components/widgets/Content.astro';
-import CallToAction from '~/components/widgets/CallToAction.astro';
 
 import { headerData } from '~/navigation';
 
@@ -142,16 +141,4 @@ const metadata = {
     </Fragment>
   </Content>
 
-  <CallToAction
-    actions={[
-      {
-        variant: 'primary',
-        text: 'Contact Us',
-        href: '/contact',
-      },
-    ]}
-  >
-    <Fragment slot="title"> MetaIntelligence </Fragment>
-    <Fragment slot="subtitle"> 세계적 수준의 기술력으로 귀사의 문제를 해결할 준비가 되어 있습니다. </Fragment>
-  </CallToAction>
 </Layout>

--- a/src/pages/tech/core-tech.astro
+++ b/src/pages/tech/core-tech.astro
@@ -140,5 +140,4 @@ const metadata = {
       <h3 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-2">기술의 가치 실현</h3>
     </Fragment>
   </Content>
-
 </Layout>

--- a/src/pages/tech/csaic-team.astro
+++ b/src/pages/tech/csaic-team.astro
@@ -3,7 +3,6 @@ import Layout from '~/layouts/PageLayout.astro';
 import Header from '~/components/widgets/Header.astro';
 import Hero2 from '~/components/widgets/Hero2.astro';
 import Content from '~/components/widgets/Content.astro';
-import CallToAction from '~/components/widgets/CallToAction.astro';
 
 import { headerData } from '~/navigation';
 
@@ -375,16 +374,4 @@ const styles = {
     </Content>
   </div>
 
-  <CallToAction
-    actions={[
-      {
-        variant: 'primary',
-        text: 'Contact CSAIC',
-        href: '/contact',
-      },
-    ]}
-  >
-    <Fragment slot="title"> Ready to Innovate? </Fragment>
-    <Fragment slot="subtitle"> 최고의 전문가들과 함께 귀사의 비즈니스 난제를 해결하세요. </Fragment>
-  </CallToAction>
 </Layout>

--- a/src/pages/tech/csaic-team.astro
+++ b/src/pages/tech/csaic-team.astro
@@ -373,5 +373,4 @@ const styles = {
       </Fragment>
     </Content>
   </div>
-
 </Layout>


### PR DESCRIPTION
## 주요 변경

- `인사이트` 메뉴 비활성화
- **솔루션 페이지 디자인 통일**: `solutions/mvi`, `solutions/ida`를 AstroWind 위젯(`Hero2`, `Features3`, `Steps`, `Features2`, `Content`, `WidgetWrapper`)으로 재구성. 데모 영상 자동재생과 스크린/비디오 셀렉터 등 인터랙티브 기능은 그대로 유지.
- **Hero 서브타이틀 굵게 처리 수정**: `company/intro`, `company/identity`에서 마크다운 `**...**`이 그대로 노출되던 문제를 `<strong>` 태그로 교체해 해결 (Hero2가 `set:html`로 렌더링).
- **불필요한 CTA 숨김**:
  - `company/intro`, `company/identity` Hero의 `Contact Us` 버튼 제거
  - `company/culture` Hero의 `Join Us` 버튼 제거
- **네비/푸터 정리**: Insights 메뉴, 푸터 크레딧, 하단 Contact CTA 숨김 처리.

## 테스트 체크리스트

- [ ] `인사이트` 메뉴 비활성화 되어 있는지 확인
- [ ] `/solutions/mvi`, `/solutions/ida` 위젯 톤이 사이트 전체와 일치하는지 확인
- [ ] MVI 데모 비디오 3종 셀렉터 동작 / IDA 화면 5종 셀렉터 동작
- [ ] `/company/intro`, `/company/identity` 서브타이틀 굵게 표시 확인
- [ ] Hero 영역에서 Contact Us / Join Us 버튼이 보이지 않는지 확인