### PR TITLE
기술 철학 페이지 하단 잔존 CTA 주석 처리

### DIFF
--- a/src/pages/tech/philosophy.astro
+++ b/src/pages/tech/philosophy.astro
@@ -71,7 +71,8 @@ const metadata = {
     ]}
   />
 
-  {/* <CallToAction
+  {
+    /* <CallToAction
     actions={[
       {
         variant: 'primary',
@@ -82,5 +83,6 @@ const metadata = {
   >
     <Fragment slot="title"> MetaIntelligence </Fragment>
     <Fragment slot="subtitle"> 본질에 집중하는 기술로 고객의 문제를 해결합니다. </Fragment>
-  </CallToAction> */}
+  </CallToAction> */
+  }
 </Layout>

--- a/src/pages/tech/philosophy.astro
+++ b/src/pages/tech/philosophy.astro
@@ -4,7 +4,7 @@ import Layout from '~/layouts/PageLayout.astro';
 import Header from '~/components/widgets/Header.astro';
 import Hero2 from '~/components/widgets/Hero2.astro';
 import Features3 from '~/components/widgets/Features3.astro';
-import CallToAction from '~/components/widgets/CallToAction.astro';
+// import CallToAction from '~/components/widgets/CallToAction.astro';
 
 import { headerData } from '~/navigation';
 

--- a/src/pages/tech/philosophy.astro
+++ b/src/pages/tech/philosophy.astro
@@ -71,7 +71,7 @@ const metadata = {
     ]}
   />
 
-  <CallToAction
+  {/* <CallToAction
     actions={[
       {
         variant: 'primary',
@@ -82,5 +82,5 @@ const metadata = {
   >
     <Fragment slot="title"> MetaIntelligence </Fragment>
     <Fragment slot="subtitle"> 본질에 집중하는 기술로 고객의 문제를 해결합니다. </Fragment>
-  </CallToAction>
+  </CallToAction> */}
 </Layout>


### PR DESCRIPTION
## 관련 이슈
- [#3 — 해당 코멘트](https://github.com/metaintelligence/metaintelligence.github.io/issues/3#issuecomment-4395024735) 에서 제기된 잔존 CTA 위젯 이슈에 대한 해결

## 변경 사항
- `src/pages/tech/philosophy.astro` 하단의 `CallToAction` 블록(Our Solutions → /solutions/mvi)을 `{/* ... */}`로 주석 처리

## 배경
- 이전 contact CTA 정리 작업(#4)에서 다른 페이지의 하단 CTA들은 제거됐으나, 본 페이지의 CTA는 링크 대상이 `/contact`가 아니라는 이유로 누락됨
- 시각적 위치·구조상 다른 페이지의 contact funnel 위젯과 동일한 역할로 인지되어 일관성을 위해 함께 숨김

## 비고
- 삭제 대신 주석 처리한 이유: 추후 contact 흐름이 정비되면 동일한 자리에 복원할 가능성이 있어 되돌리기 쉽게 둠
- `CallToAction` import도 그대로 유지

## 영향
- main 대비 파일 1개, 2줄 변경