### PR TITLE
CSAIC 팀원 페이지 프로필 링크 추가 및 일부 페이지 한글 표기 보정

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -28,7 +28,7 @@ metadata:
     cardType: summary_large_image
 
 i18n:
-  language: en
+  language: ko
   textDirection: ltr
 
 apps:

--- a/src/pages/tech/csaic-team.astro
+++ b/src/pages/tech/csaic-team.astro
@@ -44,15 +44,38 @@ const styles = {
     <Content
       isReversed
       image={{
-        src: 'https://images.unsplash.com/photo-1560250097-0b93528c311a?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80', // CEO 사진 교체 필요
-        alt: 'Dr. Seongsoo Choi',
+        src: 'https://images.unsplash.com/photo-1462331940025-496dfbfc7564?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80',
+        alt: '물리 · 우주 추상 이미지',
       }}
     >
       <Fragment slot="content">
         <div class="mb-10 border-b border-gray-200 dark:border-gray-700 pb-8">
           <span class="text-sm font-bold tracking-widest text-primary uppercase mb-3 block">CEO & Founder</span>
           <h2 class="text-4xl md:text-5xl font-bold leading-tight mb-3 text-gray-900 dark:text-white">
-            최성수 박사 <span class="text-2xl font-normal text-muted ml-2">(Ph.D. Seongsoo Choi)</span>
+            <a
+              href="https://seongsoochoi.github.io/"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-baseline gap-2 hover:text-primary dark:hover:text-blue-400 transition-colors"
+            >
+              최성수 박사
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="w-5 h-5 self-center opacity-60"
+                viewBox="0 0 24 24"
+                stroke-width="2"
+                stroke="currentColor"
+                fill="none"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                <path d="M11 7h-5a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-5"></path>
+                <path d="M10 14l10 -10"></path>
+                <path d="M15 4l5 0l0 5"></path>
+              </svg>
+            </a>
+            <span class="text-2xl font-normal text-muted ml-2">(Ph.D. Seongsoo Choi)</span>
           </h2>
           <p class="text-xl text-muted dark:text-slate-400 font-medium mb-6">
             Ph.D. in Physics · Integrated AI Solution Architect
@@ -173,8 +196,8 @@ const styles = {
   <div class="py-12 md:py-24">
     <Content
       image={{
-        src: 'https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80', // 사진 교체 필요
-        alt: 'Dr. Mina Cheon',
+        src: 'https://images.unsplash.com/photo-1456513080510-7bf3a84b82f8?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80',
+        alt: '언어 · NLP 추상 이미지',
       }}
     >
       <Fragment slot="content">
@@ -182,7 +205,31 @@ const styles = {
           <span class="text-sm font-bold tracking-widest text-purple-600 dark:text-purple-400 uppercase mb-3 block"
             >Co-Founder / AI Director</span
           >
-          <h2 class="text-4xl md:text-5xl font-bold leading-tight mb-3 text-gray-900 dark:text-white">천민아 박사</h2>
+          <h2 class="text-4xl md:text-5xl font-bold leading-tight mb-3 text-gray-900 dark:text-white">
+            <a
+              href="https://minahcheon.github.io/"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-baseline gap-2 hover:text-purple-600 dark:hover:text-purple-400 transition-colors"
+            >
+              천민아 박사
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="w-5 h-5 self-center opacity-60"
+                viewBox="0 0 24 24"
+                stroke-width="2"
+                stroke="currentColor"
+                fill="none"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                <path d="M11 7h-5a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-5"></path>
+                <path d="M10 14l10 -10"></path>
+                <path d="M15 4l5 0l0 5"></path>
+              </svg>
+            </a>
+          </h2>
           <p class="text-xl text-muted font-medium">AI(NLP) Ph.D. · LLM Specialist</p>
         </div>
 
@@ -276,8 +323,8 @@ const styles = {
     <Content
       isReversed
       image={{
-        src: 'https://images.unsplash.com/photo-1519085360753-af0119f7cbe7?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80', // 사진 교체 필요
-        alt: 'Director Woohyun Kim',
+        src: 'https://images.unsplash.com/photo-1639762681485-074b7f938ba0?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80',
+        alt: '그래픽스 · 3D 렌더 추상 이미지',
       }}
     >
       <Fragment slot="content">
@@ -285,7 +332,31 @@ const styles = {
           <span class="text-sm font-bold tracking-widest text-blue-600 dark:text-blue-400 uppercase mb-3 block"
             >Director of SW Engineering</span
           >
-          <h2 class="text-4xl md:text-5xl font-bold leading-tight mb-3 text-gray-900 dark:text-white">김우현 이사</h2>
+          <h2 class="text-4xl md:text-5xl font-bold leading-tight mb-3 text-gray-900 dark:text-white">
+            <a
+              href="https://artrointel.github.io"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-baseline gap-2 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+            >
+              김우현 이사
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="w-5 h-5 self-center opacity-60"
+                viewBox="0 0 24 24"
+                stroke-width="2"
+                stroke="currentColor"
+                fill="none"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                <path d="M11 7h-5a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-5"></path>
+                <path d="M10 14l10 -10"></path>
+                <path d="M15 4l5 0l0 5"></path>
+              </svg>
+            </a>
+          </h2>
           <p class="text-xl text-muted font-medium">Samsung Electronics MX Div. 10y · Framework/Graphics Specialist</p>
         </div>
 

--- a/src/pages/tech/csaic-team.astro
+++ b/src/pages/tech/csaic-team.astro
@@ -52,16 +52,17 @@ const styles = {
         <div class="mb-10 border-b border-gray-200 dark:border-gray-700 pb-8">
           <span class="text-sm font-bold tracking-widest text-primary uppercase mb-3 block">CEO & Founder</span>
           <h2 class="text-4xl md:text-5xl font-bold leading-tight mb-3 text-gray-900 dark:text-white">
+            최성수 박사
             <a
               href="https://seongsoochoi.github.io/"
               target="_blank"
               rel="noopener noreferrer"
-              class="inline-flex items-baseline gap-2 hover:text-primary dark:hover:text-blue-400 transition-colors"
+              aria-label="최성수 박사 개인 사이트 (새 창에서 열림)"
+              class="inline-flex items-center justify-center w-11 h-11 ml-2 align-middle rounded-full text-muted hover:text-primary hover:bg-primary/10 dark:hover:text-blue-400 dark:hover:bg-blue-400/10 transition-colors"
             >
-              최성수 박사
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                class="w-5 h-5 self-center opacity-60"
+                class="w-6 h-6"
                 viewBox="0 0 24 24"
                 stroke-width="2"
                 stroke="currentColor"
@@ -70,12 +71,11 @@ const styles = {
                 stroke-linejoin="round"
               >
                 <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                <path d="M11 7h-5a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-5"></path>
-                <path d="M10 14l10 -10"></path>
-                <path d="M15 4l5 0l0 5"></path>
+                <polyline points="5 12 3 12 12 3 21 12 19 12"></polyline>
+                <path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7"></path>
+                <path d="M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6"></path>
               </svg>
             </a>
-            <span class="text-2xl font-normal text-muted ml-2">(Ph.D. Seongsoo Choi)</span>
           </h2>
           <p class="text-xl text-muted dark:text-slate-400 font-medium mb-6">
             Ph.D. in Physics · Integrated AI Solution Architect
@@ -206,16 +206,17 @@ const styles = {
             >Co-Founder / AI Director</span
           >
           <h2 class="text-4xl md:text-5xl font-bold leading-tight mb-3 text-gray-900 dark:text-white">
+            천민아 박사
             <a
               href="https://minahcheon.github.io/"
               target="_blank"
               rel="noopener noreferrer"
-              class="inline-flex items-baseline gap-2 hover:text-purple-600 dark:hover:text-purple-400 transition-colors"
+              aria-label="천민아 박사 개인 사이트 (새 창에서 열림)"
+              class="inline-flex items-center justify-center w-11 h-11 ml-2 align-middle rounded-full text-muted hover:text-purple-600 hover:bg-purple-600/10 dark:hover:text-purple-400 dark:hover:bg-purple-400/10 transition-colors"
             >
-              천민아 박사
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                class="w-5 h-5 self-center opacity-60"
+                class="w-6 h-6"
                 viewBox="0 0 24 24"
                 stroke-width="2"
                 stroke="currentColor"
@@ -224,9 +225,9 @@ const styles = {
                 stroke-linejoin="round"
               >
                 <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                <path d="M11 7h-5a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-5"></path>
-                <path d="M10 14l10 -10"></path>
-                <path d="M15 4l5 0l0 5"></path>
+                <polyline points="5 12 3 12 12 3 21 12 19 12"></polyline>
+                <path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7"></path>
+                <path d="M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6"></path>
               </svg>
             </a>
           </h2>
@@ -333,16 +334,17 @@ const styles = {
             >Director of SW Engineering</span
           >
           <h2 class="text-4xl md:text-5xl font-bold leading-tight mb-3 text-gray-900 dark:text-white">
+            김우현 이사
             <a
               href="https://artrointel.github.io"
               target="_blank"
               rel="noopener noreferrer"
-              class="inline-flex items-baseline gap-2 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+              aria-label="김우현 이사 개인 사이트 (새 창에서 열림)"
+              class="inline-flex items-center justify-center w-11 h-11 ml-2 align-middle rounded-full text-muted hover:text-blue-600 hover:bg-blue-600/10 dark:hover:text-blue-400 dark:hover:bg-blue-400/10 transition-colors"
             >
-              김우현 이사
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                class="w-5 h-5 self-center opacity-60"
+                class="w-6 h-6"
                 viewBox="0 0 24 24"
                 stroke-width="2"
                 stroke="currentColor"
@@ -351,9 +353,9 @@ const styles = {
                 stroke-linejoin="round"
               >
                 <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                <path d="M11 7h-5a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-5"></path>
-                <path d="M10 14l10 -10"></path>
-                <path d="M15 4l5 0l0 5"></path>
+                <polyline points="5 12 3 12 12 3 21 12 19 12"></polyline>
+                <path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7"></path>
+                <path d="M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6"></path>
               </svg>
             </a>
           </h2>


### PR DESCRIPTION
## 변경 사항

### **CSAIC 팀원 페이지** (`/tech/csaic-team`)
- 각 팀원 카드에 개인 홈페이지로 가는 작은 홈 아이콘 버튼을 추가
- 기존 인물 사진은 전공 분야를 떠올릴 수 있는 추상 이미지(우주 / 언어 / 3D 렌더)로 교체
- 최성수 박사 옆에 중복되던 "(Ph.D. Seongsoo Choi)" 표기를 정리

### 회사 소개 관련 페이지 한글로 표시
- `/company/mission-history`, `/company/intro`, `/company/identity` 세 페이지가 영문으로 노출되던 부분(미션 본문 등)을 한글로 표시되도록 사이트 기본 언어 설정을 한국어로 맞춤
- 기존에 한국어 번역은 이미 작성돼 있었지만 설정값이 맞지 않아 영문이 보이던 상태였음

## 확인 부탁드릴 부분

- [ ] `/tech/csaic-team`에서 세 팀원 이름 옆 홈 아이콘 클릭 시 각자 페이지로 잘 이동하는지
  - 김우현: https://artrointel.github.io
  - 최성수: https://seongsoochoi.github.io/
  - 천민아: https://minahcheon.github.io/
- [ ] 모바일에서도 아이콘이 누르기 편한 크기로 보이는지
- [ ] `/company/mission-history`, `/company/intro`, `/company/identity` 본문이 한글로 자연스럽게 보이는지 (의도와 다른 부분 있는지)


---

해당 리뷰가 끝나면 한/영 토글에 대한 작업 시작하겠습니다.